### PR TITLE
add new version of membrane-soa-model 1.5.0.wso2v3

### DIFF
--- a/membrane-soa-model/1.5.0.wso2v3/pom.xml
+++ b/membrane-soa-model/1.5.0.wso2v3/pom.xml
@@ -54,10 +54,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Description>OSGI version of ${project.name}</Bundle-Description>
                         <Export-Package>
-                            com.predic8.*;version="1.5.0",
-                            groovy.xml.*;version="2.3.9",
-                            groovy.util.*;version="2.3.9",
-                            groovy.lang.*;version="2.3.9"
+                            com.predic8.*;version="1.5.0"
                         </Export-Package>
                         <Import-Package>
                             org.objectweb.asm;version="[4.0.0, 4.1.0)",
@@ -71,13 +68,11 @@
                             com.thoughtworks.xstream.*;resolution:=optional,
                             org.fusesource.jansi.*;resolution:=optional,
                             org.w3c.dom.*;resolution:=optional,
-                            org.xml.sax.*;resolution:=optional
+                            org.xml.sax.*;resolution:=optional,
+                            groovy.*;resolution:=optional,
+                            org.codehaus.groovy.*;resolution:=optional
                         </Import-Package>
                         <Include-Resource>@soa-model-core-1.5.0.jar!/*</Include-Resource>
-                        <Embed-Dependency>
-                            groovy;scope=compile|runtime;inline=false,
-                            groovy-xml;scope=compile|runtime;inline=false
-                        </Embed-Dependency>
                     </instructions>
                 </configuration>
                 <extensions>true</extensions>

--- a/membrane-soa-model/1.5.0.wso2v3/pom.xml
+++ b/membrane-soa-model/1.5.0.wso2v3/pom.xml
@@ -60,7 +60,7 @@
                             org.objectweb.asm;version="[4.0.0, 4.1.0)",
                             groovy.json;version="[2.3.9, 3.0.0)",
                             org.apache.commons.cli;version="[1.2.0, 1.3.0)",
-                            org.apache.http.*;version="[4.3.3.wso2v1 ,4.3.3.wso2v2)",
+                            org.apache.http.*;version="[4.3.0 ,4.4.0)",
                             org.slf4j;version="[1.6.1 ,1.7.0)",
                             javax.swing.*;resolution:=optional,
                             javax.xml.*;resolution:=optional,

--- a/membrane-soa-model/1.5.0.wso2v3/pom.xml
+++ b/membrane-soa-model/1.5.0.wso2v3/pom.xml
@@ -87,18 +87,7 @@
             <version>1.5.0</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>2.3.9</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-xml</artifactId>
-            <version>2.3.9</version>
-            <optional>true</optional>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/membrane-soa-model/1.5.0.wso2v3/pom.xml
+++ b/membrane-soa-model/1.5.0.wso2v3/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.orbit.com.predic8</groupId>
+    <artifactId>soa.model.core</artifactId>
+    <version>1.5.0.wso2v3</version>
+    <packaging>bundle</packaging>
+    <description>
+        com.predic8.wso2. This bundle will export packages from soa-model-core-1.5.0.wso2v2.jar
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <configuration>
+                    <instructions>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Description>OSGI version of ${project.name}</Bundle-Description>
+                        <Export-Package>
+                            com.predic8.*;version="1.5.0",
+                            groovy.xml.*;version="2.3.9",
+                            groovy.util.*;version="2.3.9",
+                            groovy.lang.*;version="2.3.9"
+                        </Export-Package>
+                        <Import-Package>
+                            org.objectweb.asm;version="[4.0.0, 4.1.0)",
+                            groovy.json;version="[2.3.9, 3.0.0)",
+                            org.apache.commons.cli;version="[1.2.0, 1.3.0)",
+                            org.apache.http.*;version="[4.3.3.wso2v1 ,4.3.3.wso2v2)",
+                            org.slf4j;version="[1.6.1 ,1.7.0)",
+                            javax.swing.*;resolution:=optional,
+                            javax.xml.*;resolution:=optional,
+                            org.apache.ivy.*;resolution:=optional,
+                            com.thoughtworks.xstream.*;resolution:=optional,
+                            org.fusesource.jansi.*;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            org.xml.sax.*;resolution:=optional
+                        </Import-Package>
+                        <Include-Resource>@soa-model-core-1.5.0.jar!/*</Include-Resource>
+                        <Embed-Dependency>
+                            groovy;scope=compile|runtime;inline=false,
+                            groovy-xml;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.predic8</groupId>
+            <artifactId>soa-model-core</artifactId>
+            <version>1.5.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>2.3.9</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-xml</artifactId>
+            <version>2.3.9</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/membrane-soa-model/1.5.0.wso2v3/pom.xml
+++ b/membrane-soa-model/1.5.0.wso2v3/pom.xml
@@ -87,7 +87,6 @@
             <version>1.5.0</version>
             <optional>true</optional>
         </dependency>
-
     </dependencies>
 
 </project>


### PR DESCRIPTION
add new version of membrane-soa-model 1.5.0.wso2v3 with by exporting groovy.util.* and  groovy.lang.*