### PR TITLE
Updated org.slf4j version range

### DIFF
--- a/waffle/1.6.wso2v2/pom.xml
+++ b/waffle/1.6.wso2v2/pom.xml
@@ -108,7 +108,7 @@
                             org.apache.catalina.deploy;resolution:=optional,
                             org.apache.catalina.realm;resolution:=optional,
                             org.w3c.dom;resolution:=optional,
-                            org.slf4j.*;version="[1.6.1,1.7)"
+                            org.slf4j.*;version="[1.6.1,1.8)"
                         </Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
Have to update slf4j range due to org.slf4j.impl import get conflicted with 1.7.x.
Updated after testing it. slf4j is compatible between 1.6.x and 1.7.x - (http://www.slf4j.org/manual.html)