### PR TITLE
Adding new version of hadoop client with import constrains

### DIFF
--- a/hadoop-client/2.6.0.wso2v3/pom.xml
+++ b/hadoop-client/2.6.0.wso2v3/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except

--- a/hadoop-client/2.6.0.wso2v3/pom.xml
+++ b/hadoop-client/2.6.0.wso2v3/pom.xml
@@ -143,7 +143,7 @@
                             javax.servlet.jsp.*;version ="${servlet-jsp.import.version}",
                             javax.servlet.*;version ="${servlet-api.import.version}",
                             org.slf4j.*;version="${slf4j.import.version}",
-			    com.google.common.*;version="${guava.version.range}",
+                            com.google.common.*;version="${guava.version.range}",
                             com.google.protobuf.*;version="${protobuf.import.version}",
                             org.htrace.*;version="${htrace.import.version}",
                             org.apache.commons.io.*;version="${commons-io.import.version}",
@@ -171,7 +171,7 @@
         <slf4j.import.version>[1.6.0, 1.8.0)</slf4j.import.version>
         <protobuf.import.version>[2.5.0, 2.6.0)</protobuf.import.version>
         <commons-io.import.version>[2.4.0, 2.5.0)</commons-io.import.version>
-	<guava.version.range>[15.0.0, 16.0.0)</guava.version.range>
+        <guava.version.range>[15.0.0, 16.0.0)</guava.version.range>
     </properties>
 
 </project>

--- a/hadoop-client/2.6.0.wso2v3/pom.xml
+++ b/hadoop-client/2.6.0.wso2v3/pom.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.apache.hadoop</groupId>
+    <artifactId>hadoop-client</artifactId>
+    <version>2.6.0.wso2v3</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Apache Hadoop Client Bundle</name>
+    <description>
+        This bundle will export packages from Apache Hadoop client
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>${hadoop.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>${hadoop.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-annotations</artifactId>
+            <version>${hadoop.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>${hadoop.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-app</artifactId>
+            <version>${hadoop.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
+            <version>${hadoop.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-api</artifactId>
+            <version>${hadoop.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.htrace</groupId>
+            <artifactId>htrace-core</artifactId>
+            <version>${htrace.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            !org.apache.hadoop.application-classloader.*,org.apache.hadoop.*;version="${project.version}";-split-package:=merge-first
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !org.apache.hadoop.*,
+                            javax.servlet.jsp.*;version ="${servlet-jsp.import.version}",
+                            javax.servlet.*;version ="${servlet-api.import.version}",
+                            org.slf4j.*;version="${slf4j.import.version}",
+			    com.google.common.*;version="${guava.version.range}",
+                            com.google.protobuf.*;version="${protobuf.import.version}",
+                            org.htrace.*;version="${htrace.import.version}",
+                            org.apache.commons.io.*;version="${commons-io.import.version}",
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Include-Resource>
+                            {maven-resources},
+                            @hadoop-common-${hadoop.version}.jar!/*.xml,
+                            @hadoop-common-${hadoop.version}.jar!/*.properties,
+                            @hadoop-common-${hadoop.version}.jar!/META-INF/services/*,
+                            @hadoop-hdfs-${hadoop.version}.jar!/*.xml,
+                        </Include-Resource>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <hadoop.version>2.6.0</hadoop.version>
+        <htrace.version>3.0.4</htrace.version>
+        <commons-io.version>2.4</commons-io.version>
+        <htrace.import.version>[3.0.4, 3.1.0)</htrace.import.version>
+        <servlet-api.import.version>[2.5, 3.0)</servlet-api.import.version>
+        <servlet-jsp.import.version>[2.2.1, 2.3.0)</servlet-jsp.import.version>
+        <slf4j.import.version>[1.6.0, 1.8.0)</slf4j.import.version>
+        <protobuf.import.version>[2.5.0, 2.6.0)</protobuf.import.version>
+        <commons-io.import.version>[2.4.0, 2.5.0)</commons-io.import.version>
+	<guava.version.range>[15.0.0, 16.0.0)</guava.version.range>
+    </properties>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
         <module>lucene/4.10.3-wso2v1</module>
         <module>rabbit-mq/3.4.4.wso2v1</module>
         <module>scannotation/1.0.3.wso2v1</module>
-	<module>hadoop-client/2.6.0.wso2v3</module>
     </modules>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <module>lucene/4.10.3-wso2v1</module>
         <module>rabbit-mq/3.4.4.wso2v1</module>
         <module>scannotation/1.0.3.wso2v1</module>
+	<module>hadoop-client/2.6.0.wso2v3</module>
     </modules>
 
     <build>


### PR DESCRIPTION
This change fixes an OSGI issue that pops up due to hadoop client using a version of guava library that is not constrained. The issue was encountered when installing DAS features along with MB (MB uses a higher version of guava). Hence the version range is constrained to [15.0.0, 16.0.0).