### PR TITLE
Changing bundle-plugin version for jscep 2.3

### DIFF
--- a/jscep/2.3.0.wso2v1/pom.xml
+++ b/jscep/2.3.0.wso2v1/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>1.4.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
When using bundle plugin 2.4, the jar is packed as empty. We need to use 1.4