### PR TITLE
Add AWS Marketplace Metering and Entitlement Services

### DIFF
--- a/aws-marketplace-services/1.11.188.wso2v1/pom.xml
+++ b/aws-marketplace-services/1.11.188.wso2v1/pom.xml
@@ -1,0 +1,90 @@
+<!--
+ ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.amazonaws</groupId>
+    <artifactId>aws-java-sdk-marketplace-services</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Amazon Marketplace Services</name>
+    <version>1.11.188.wso2v1</version>
+    <description>
+        This bundle contains the following aws-java-sdk-marketplace services:
+            1. aws-java-sdk-marketplacemeteringservice
+            2. aws-java-sdk-marketplaceentitlement
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-marketplacemeteringservice</artifactId>
+            <version>${aws-marketplacemeteringservice.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-marketplaceentitlement</artifactId>
+            <version>${aws-marketplacemeentitlement.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.amazonaws.*;version="${aws-marketplace-services.version}"
+                        </Export-Package>
+                        <Import-Package>
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Embed-Dependency>*;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <aws-marketplace-services.version>1.11.188</aws-marketplace-services.version>
+        <aws-marketplacemeentitlement.version>1.11.188</aws-marketplacemeentitlement.version>
+        <aws-marketplacemeteringservice.version>1.11.188</aws-marketplacemeteringservice.version>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose
Add AWS Marketplace Metering Service and Entitlement Service as an orbit bundle.

## Release note
Add AWS Marketplace Metering Service and Entitlement Service as an orbit bundle.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
