### PR TITLE
Upgrade common-codec dependency

### DIFF
--- a/commons-codec/1.4.0.wso2v1/pom.xml
+++ b/commons-codec/1.4.0.wso2v1/pom.xml
@@ -1,0 +1,64 @@
+<!--
+ ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>commons-codec.wso2</groupId>
+    <artifactId>commons-codec</artifactId>
+    <packaging>bundle</packaging>
+    <name>commons.codec.wso2</name>
+    <version>${orbit.codec.version}</version>
+    <description>
+        This bundle will export packages from commons-codec.jar
+    </description>
+    <url>http://wso2.org</url>
+    <dependencies>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>1.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>org.apache.commons.codec.*;version=${export.package.version}</Export-Package>
+                        <Import-Package>
+                            !org.apache.commons.codec.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <orbit.codec.version>1.4.0.wso2v1</orbit.codec.version>
+        <commons-codec.version>1.10</commons-codec.version>
+        <export.package.version>1.4</export.package.version>
+    </properties>
+</project>

--- a/commons-codec/1.4.0.wso2v1/pom.xml
+++ b/commons-codec/1.4.0.wso2v1/pom.xml
@@ -49,7 +49,8 @@
                         <Export-Package>org.apache.commons.codec.*;version=${export.package.version}</Export-Package>
                         <Import-Package>
                             !org.apache.commons.codec.*,
-                            *
+                            javax.crypto.*,
+                            javax.crypto.spec.*
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/commons-codec/1.4.0.wso2v1/pom.xml
+++ b/commons-codec/1.4.0.wso2v1/pom.xml
@@ -59,6 +59,6 @@
     <properties>
         <orbit.codec.version>1.4.0.wso2v1</orbit.codec.version>
         <commons-codec.version>1.10</commons-codec.version>
-        <export.package.version>1.4</export.package.version>
+        <export.package.version>1.10</export.package.version>
     </properties>
 </project>

--- a/commons-codec/1.4.0.wso2v1/pom.xml
+++ b/commons-codec/1.4.0.wso2v1/pom.xml
@@ -49,7 +49,7 @@
                         <Export-Package>org.apache.commons.codec.*;version=${export.package.version}</Export-Package>
                         <Import-Package>
                             !org.apache.commons.codec.*,
-                            *;
+                            *
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/commons-codec/1.4.0.wso2v1/pom.xml
+++ b/commons-codec/1.4.0.wso2v1/pom.xml
@@ -19,7 +19,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>commons-codec.wso2</groupId>
+    <groupId>org.wso2.orbit.commons-codec</groupId>
     <artifactId>commons-codec</artifactId>
     <packaging>bundle</packaging>
     <name>commons-codec.wso2</name>

--- a/commons-codec/1.4.0.wso2v1/pom.xml
+++ b/commons-codec/1.4.0.wso2v1/pom.xml
@@ -22,7 +22,7 @@
     <groupId>commons-codec.wso2</groupId>
     <artifactId>commons-codec</artifactId>
     <packaging>bundle</packaging>
-    <name>commons.codec.wso2</name>
+    <name>commons-codec.wso2</name>
     <version>${orbit.codec.version}</version>
     <description>
         This bundle will export packages from commons-codec.jar
@@ -49,7 +49,7 @@
                         <Export-Package>org.apache.commons.codec.*;version=${export.package.version}</Export-Package>
                         <Import-Package>
                             !org.apache.commons.codec.*,
-                            *;resolution:=optional
+                            *;
                         </Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
## Purpose
Upgrade the commons-codec dependency version to 1.10

## Goals
Upgrade the commons-codec dependency version to 1.10

## Release note
Upgrade the commons-codec dependency version from 1.4 to 1.10

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes