### PR TITLE
Change geeonimo-saaj javax.xml.soap export version

### DIFF
--- a/geronimo-saaj_1.3_spec/1.0.1.wso2v2/pom.xml
+++ b/geronimo-saaj_1.3_spec/1.0.1.wso2v2/pom.xml
@@ -1,0 +1,77 @@
+<!--
+ ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.apache.geronimo.specs</groupId>
+    <artifactId>geronimo-saaj_1.3_spec</artifactId>
+    <packaging>bundle</packaging>
+    <name>geronimo saaj 1.3 spec orbit bundle</name>
+    <version>1.0.1.wso2v2</version>
+    <description>
+        This bundle will represent geronimo-saaj_1.3_spec.jar
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-saaj_1.3_spec</artifactId>
+            <version>${geronimo.saaj.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Vendor>WSO2, Inc.</Bundle-Vendor>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            javax.xml.soap;version="1.0.0",
+                        </Export-Package>
+                        <Fragment-Host>system.bundle; extension:=framework</Fragment-Host>
+                        <_removeheaders>Import-Package</_removeheaders>
+                        <_failok>true</_failok>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <geronimo.saaj.version>1.0.1</geronimo.saaj.version>
+        <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose
Changed geeonimo-saaj javax.xml.soap export version to 1.0.0

## Release note
* Change geeonimo-saaj javax.xml.soap export version to 1.0.0

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes