### PR TITLE
Add docker-client/1.2.2wso2v3 

### DIFF
--- a/docker-client/1.2.2.wso2v3/pom.xml
+++ b/docker-client/1.2.2.wso2v3/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.io.fabric8</groupId>
+    <artifactId>docker-client</artifactId>
+    <version>1.2.2.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>docker-client.wso2</name>
+    <description>
+        This bundle exports io.fabric8.docker
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-client</artifactId>
+            <version>${docker-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-dsl</artifactId>
+            <version>${docker-dsl.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-model</artifactId>
+            <version>${docker-model.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Vendor>WSO2, Inc.</Bundle-Vendor>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.fabric8.docker.*;version="${project.version}";-split-package:=merge-first
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !io.fabric8.docker.*,
+                            com.fasterxml.jackson.annotation;version="[2.7.0,3.0.0)",
+                            com.fasterxml.jackson.databind;version="[2.7.0,3.0.0)",
+                            com.fasterxml.jackson.databind.type;version="[2.7.0,3.0.0)",
+                            okhttp3;version="[2.7.2,4.0.0)",
+                            okhttp3.logging;version="[2.7.2,4.0.0)",
+                            okhttp3.ws;version="[2.7.2,4.0.0)",
+                            io.fabric8.docker.api.builder;version="[1.0.0,2.0.0)",
+                            io.fabric8.docker.api.model;version="[1.0.0,2.0.0)",
+                            io.fabric8.docker.dsl;version="[1.0.0,2.0.0)",
+                            io.fabric8.docker.dsl.container;version="[1.0.0,2.0.0)",
+                            io.fabric8.docker.dsl.image;version="[1.0.0,2.0.0)",
+                            io.fabric8.docker.dsl.misc;version="[1.0.0,2.0.0)",
+                            io.fabric8.docker.dsl.network;version="[1.0.0,2.0.0)",
+                            io.fabric8.docker.dsl.volume;version="[1.0.0,2.0.0)",
+                            javax.net;version="[0.0.0,1.0.0)",
+                            javax.net.ssl;version="[0.0.0,1.0.0)",
+                            javax.security.auth.x500;version="[0.0.0,1.0.0)",
+                            javax.validation;version="[1.1.0,2.0.0)",
+                            okio;version="[1.6.0,2.0.0)",
+                            org.apache.commons.codec.binary;version="[1.4.0, 1.5.0)",
+                            org.apache.commons.compress.archivers;version="[1.9.0,2.0.0)",
+                            org.apache.commons.compress.archivers.tar;version="[1.9.0,2.0.0)",
+                            org.apache.commons.compress.compressors.bzip2;version="[1.9.0,2.0.0)",
+                            org.newsclub.net.unix;version="[2.0.0,2.1.0)",
+                            org.slf4j;version="[1.7.0,2.0.0)"
+                        </Import-Package>
+                        <Include-Resource>
+                            {maven-resources}
+                        </Include-Resource>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <docker-client.version>1.2.2</docker-client.version>
+        <docker-dsl.version>1.2.2</docker-dsl.version>
+        <docker-model.version>1.2.2</docker-model.version>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose
> changing org.apache.commons.codec version 

## Goals
> make this jar compatible with carbon version 4.4.1

## Approach
> remove  org.apache.commons.codec.binary;version="[1.10.0,2.0.0)" and make it org.apache.commons.codec.binary;version="[1.4.0, 1.5.0)".

## User stories
> N/A 

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Java 8 
 
## Learning
> N/A