### PR TITLE
product-is:1956 Adding csrfguard-3.1.0.wso2v3

### DIFF
--- a/csrfguard/3.1.0.wso2v3/pom.xml
+++ b/csrfguard/3.1.0.wso2v3/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+      <groupId>org.wso2</groupId>
+      <artifactId>wso2</artifactId>
+      <version>1</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.owasp</groupId>
+    <artifactId>csrfguard</artifactId>
+    <packaging>bundle</packaging>
+    <name>org.owasp.csrfguard</name>
+    <version>3.1.0.wso2v3</version>
+    <description>
+        This bundle will export packages from owasp csrfguard
+    </description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.org.owasp</groupId>
+            <artifactId>csrfguard</artifactId>
+            <version>${version.csrfguard}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.owasp.csrfguard.*;version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+			    !org.owasp.csrfguardorg.*,
+                            javax.servlet.jsp.*; version="${javax.servlet.jsp.version}",
+                            javax.servlet.*;version="${javax.servlet.version}"
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Include-Resource>
+                            @csrfguard-${version.csrfguard}.jar
+                        </Include-Resource>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <version.csrfguard>3.1.0-wso2v1</version.csrfguard>
+        <javax.servlet.version>[2.6.0,3.0.0)</javax.servlet.version>
+        <javax.servlet.jsp.version>[2.2.0,2.3.0)</javax.servlet.jsp.version>
+    </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+</project>


### PR DESCRIPTION
## Purpose
> As per [this issue](https://github.com/wso2/product-is/issues/1956) the CSRFGuard library is affected with JDK-8189789 bug. This PR has been created to wrap a new release of CSRFGuard which avoids the code affected by JDK-8189789.

## Goals
> To let the users with any environment (e.g. MacOS HighSierra, JDK 8 any update) to run WSO2 products without an issue.

## Approach
> Forking the library code and modifying the HTTP response generating code to prevent manipulating the output stream directly.

