### PR TITLE
Revert javax.servlet and org.apache.jasper export version

### DIFF
--- a/tomcat-jsp-api/9.0.21.wso2v1/pom.xml
+++ b/tomcat-jsp-api/9.0.21.wso2v1/pom.xml
@@ -56,12 +56,12 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
-                            javax.servlet.jsp.*;version="2.3.0"
+                            javax.servlet.jsp.*;version="2.2.0"
                         </Export-Package>
                         <Import-Package>
                             javax.el;version="[3.0.0, 3.1.0)",
-                            javax.servlet;version="[4.0.0, 4.1.0)",
-                            javax.servlet.http;version="[4.0.0, 4.1.0)",
+                            javax.servlet;version="[2.6.0, 2.7.0)",
+                            javax.servlet.http;version="[2.6.0, 2.7.0)",
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/tomcat-servlet-api/9.0.21.wso2v1/pom.xml
+++ b/tomcat-servlet-api/9.0.21.wso2v1/pom.xml
@@ -56,7 +56,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
-                            javax.servlet.*;version="4.0.0"
+                            javax.servlet.*;version="2.6.0"
                         </Export-Package>
                         <Private-Package>
                         </Private-Package>

--- a/tomcat/9.0.21.wso2v1/pom.xml
+++ b/tomcat/9.0.21.wso2v1/pom.xml
@@ -104,7 +104,7 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
                             !org.apache.tomcat.jdbc.pool.*,
-                            org.apache.jasper.*;version="${version.tomcat}";-split-package:=merge-first,
+                            org.apache.jasper.*;version="2.2.2";-split-package:=merge-first,
                             org.apache.naming.*;version="${version.tomcat}",
                             org.apache.tomcat.*;version="${version.tomcat}";-split-package:=merge-first,
                             org.apache.catalina.*;version="${version.tomcat}",


### PR DESCRIPTION
## Purpose
> Revert javax.servlet and org.apache.jasper export version. The reason is the current equinox.http.servlet version expects these range. Updating the equinox.http.servlet version is not possible currently as the current servlet bridging needs to be rewritten with new implementation
