### PR TITLE
feat() : Update version OpenAPITools

### DIFF
--- a/swagger-parser/2.0.13.OpenAPITools.wso2v1/pom.xml
+++ b/swagger-parser/2.0.13.OpenAPITools.wso2v1/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.orbit.org.openapitools.swagger.parser</groupId>
     <artifactId>swagger-parser</artifactId>
-    <version>2.0.13.OpenAPITools.wso2v1</version>
+    <version>2.0.14.OpenAPITools.wso2v1</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon Orbit - swagger-parser (io.swagger)</name>
     <description>
@@ -43,17 +43,17 @@
         <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>2.0.13-OpenAPITools.org-1</version>
+            <version>2.0.14-OpenAPITools.org-1</version>
         </dependency>
         <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser-v2-converter</artifactId>
-            <version>2.0.13-OpenAPITools.org-1</version>
+            <version>2.0.14-OpenAPITools.org-1</version>
         </dependency>
         <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser-v3</artifactId>
-            <version>2.0.13-OpenAPITools.org-1</version>
+            <version>2.0.14-OpenAPITools.org-1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -64,12 +64,12 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-core</artifactId>
-            <version>1.5.22</version>
+            <version>1.5.24</version>
         </dependency>
         <dependency>    
             <groupId>io.swagger</groupId>
             <artifactId>swagger-models</artifactId>
-            <version>1.5.22</version>
+            <version>1.5.24</version>
         </dependency>
     </dependencies>
 
@@ -129,7 +129,7 @@
     </build>
 
     <properties>
-        <export.pkg.version.swagger-parser>2.0.13.OpenAPITools.wso2v1</export.pkg.version.swagger-parser>
+        <export.pkg.version.swagger-parser>2.0.14.OpenAPITools.wso2v1</export.pkg.version.swagger-parser>
         <slf4j.import.version>[1.7.0, 1.8.0)</slf4j.import.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
## Purpose

wso2/product-apim#7893

When I provide a OpenAPI 3.0.1 file for my API with additionalProperties set to false in the schemas, I get an error telling that "OpenAPI content validation failed!".
The OpenAPI specification indicates that additionalProperties can be either a boolean or an object.

## Steps to reproduce:
* Connect to the Publisher
* Click on Create API and then I have an existing REST API
* Provide the URL of a OpenAPI file with additionalProperties set to false in the schemas
=> I get the error "OpenAPI content validation failed!"
In the developer tools, I can see that the endpoint validate-openapi returns many errors of type "attribute components.schemas.XXX.additionalProperties is not of type 'object'"

## Goals
> Update of a swagger-parser package with a correct version of OpenAPITools. Version update to 2.0.14

## Migrations (if applicable)
> You must update the carbon-apimgt file `pom.xml` in order to add the jar `swagger-parser-2.0.14.OpenAPITools.wso2v1` via the tag `<openapitools.swagger.parser.version>`

## Test environment
> Env (Docker/K8s): K8s cluster (Rancher)
> API-M 3.1.0 