### PR TITLE
Upgrade the version of swagger parser to 2.0.13-OpenAPITools.org-2 without changing the package name 2.0.13.OpenAPITools.wso2v1 

### DIFF
--- a/swagger-parser/2.0.13.OpenAPITools.wso2v1/pom.xml
+++ b/swagger-parser/2.0.13.OpenAPITools.wso2v1/pom.xml
@@ -43,17 +43,17 @@
         <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>2.0.13-OpenAPITools.org-1</version>
+            <version>2.0.13-OpenAPITools.org-2</version>
         </dependency>
         <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser-v2-converter</artifactId>
-            <version>2.0.13-OpenAPITools.org-1</version>
+            <version>2.0.13-OpenAPITools.org-2</version>
         </dependency>
         <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser-v3</artifactId>
-            <version>2.0.13-OpenAPITools.org-1</version>
+            <version>2.0.13-OpenAPITools.org-2</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/7893
Fixes: https://github.com/wso2/product-apim/issues/8185

## Goals
Update the swagger-parser with [2.0.13.OpenAPITools.org-2](https://github.com/OpenAPITools/swagger-parser/releases/tag/v2.0.13-OpenAPITools.org-2)

## Approach
- Changed the pom of 2.0.13.OpenAPITools.wso2v1 with [2.0.13.OpenAPITools.org-2](https://github.com/OpenAPITools/swagger-parser/releases/tag/v2.0.13-OpenAPITools.org-2). 
- Only the internal packages in the pom have been changed. The name of the orbit package will remain as 2.0.13.OpenAPITools.wso2v1 without a change.