### PR TITLE
Revert "Upgrade the version of swagger parser to 2.0.13-OpenAPITools.org-2 without changing the package name 2.0.13.OpenAPITools.wso2v1 "

### DIFF
--- a/swagger-parser/2.0.13.OpenAPITools.wso2v1/pom.xml
+++ b/swagger-parser/2.0.13.OpenAPITools.wso2v1/pom.xml
@@ -43,17 +43,17 @@
         <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>2.0.13-OpenAPITools.org-2</version>
+            <version>2.0.13-OpenAPITools.org-1</version>
         </dependency>
         <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser-v2-converter</artifactId>
-            <version>2.0.13-OpenAPITools.org-2</version>
+            <version>2.0.13-OpenAPITools.org-1</version>
         </dependency>
         <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser-v3</artifactId>
-            <version>2.0.13-OpenAPITools.org-2</version>
+            <version>2.0.13-OpenAPITools.org-1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
## Purpose
Reverts wso2/orbit#423

**Reason**: Currently, we  have 2.0.13.OpenAPITools.wso2v1 [1] swagger parser which was created from OpenAPITools [2] (which is a forked directory of the base swagger parser in [3]). The latest OpenAPITool swagger parser version is 2.0.14-OpenAPITools.org-1 [4] which is based on the base swagger parser release 2.0.14 [5]. Still, OpenAPITools has not done a release for base swagger parser latest version which is 2.0.20. 
So, our aim is to revert the PR wso2/orbit#423 and move to the previous version, until we find a way to incorporate the latest version (2.0.20) of the base swagger parser, directly.

[1]. https://github.com/wso2/orbit/tree/master/swagger-parser/2.0.13.OpenAPITools.wso2v1
[2]. https://github.com/OpenAPITools/swagger-parser/
[3]. https://github.com/swagger-api/swagger-parser
[4]. https://github.com/OpenAPITools/swagger-parser/releases/tag/v2.0.14-OpenAPITools.org-1
[5]. https://github.com/swagger-api/swagger-parser/releases/tag/v2.0.14