### PR TITLE
Add latest httpmime, openid4java, yubico version

### DIFF
--- a/httpmime/4.5.13.wso2v1/pom.xml
+++ b/httpmime/4.5.13.wso2v1/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+    <artifactId>httpmime</artifactId>
+    <packaging>bundle</packaging>
+    <name>HttpMime</name>
+    <version>4.5.13.wso2v1</version>
+    <description>A custom bundle that wraps httpmime</description>
+    <url>http://www.wso2.com</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>${httpmime.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.apache.http.entity.mime.*; version="${httpmime.orbit.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.apache.http.util; version="${httpcore.imp.pkg.version.range}",
+                            org.apache.http.message; version="${httpcore.imp.pkg.version.range}",
+                            org.apache.http.entity; version="${httpcore.imp.pkg.version.range}",
+                            org.apache.http; version="${httpcore.imp.pkg.version.range}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <httpmime.version>4.5.13</httpmime.version>
+        <httpmime.orbit.version>${httpmime.version}.wso2v1</httpmime.orbit.version>
+        <httpcore.imp.pkg.version.range>[4.4, 4.5)</httpcore.imp.pkg.version.range>
+    </properties>
+</project>

--- a/openid4java/1.0.0.wso2v5/pom.xml
+++ b/openid4java/1.0.0.wso2v5/pom.xml
@@ -1,0 +1,192 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.openid4java</groupId>
+    <artifactId>openid4java</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - OpenID4Java Library</name>
+    <version>1.0.0.wso2v5</version>
+    <description>
+        This bundle will export packages from OpenID4Java library.
+    </description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openid4java</groupId>
+            <artifactId>openid4java</artifactId>
+            <version>${openid4java.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.openxri</groupId>
+            <artifactId>openxri-client</artifactId>
+            <version>${openxri-client.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xalan</groupId>
+                    <artifactId>xalan</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jcl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jug</groupId>
+                    <artifactId>jug</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-security</groupId>
+                    <artifactId>xmlsec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.openxri</groupId>
+            <artifactId>openxri-syntax</artifactId>
+            <version>${openxri-syntax.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.ibm.icu</groupId>
+                    <artifactId>icu4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jcl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.nekohtml</groupId>
+            <artifactId>nekohtml</artifactId>
+            <version>${nekohtml.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>1.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Vendor>WSO2 Inc</Bundle-Vendor>
+                        <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.openid4java.*; version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            !org.openid4java.*,
+                            com.google.inject;version="${code.google.imp.pkg.version.range}",
+                            javax.crypto.*;version="${javax.crypto.version}",
+                            javax.net.*;version="${javax.net.version}",
+                            javax.servlet.*;version="${javax.servlet.imp.pkg.version.range}",
+                            javax.xml.*;version="${javax.xml.version}",
+                            net.sf.ehcache;version="${net.sf.ehcache.imp.pkg.version.range}",
+                            org.apache.commons.codec.*;version="${commons.codec.imp.pkg.version.range}",
+                            org.apache.commons.logging; version="${commons.logging.imp.pkg.version.range}",
+                            org.apache.html.*;resolution:=optional,
+                            org.apache.http.conn.*; version="${http.client.imp.pkg.version.range}",
+                            org.apache.http.auth; version="${http.client.imp.pkg.version.range}",
+                            org.apache.http.client.*; version="${http.client.imp.pkg.version.range}",
+                            org.apache.http.impl.conn.*; version="${http.client.imp.pkg.version.range}",
+                            org.apache.http.impl.client; version="${http.client.imp.pkg.version.range}",
+                            org.apache.http.*; version="${http.imp.pkg.version.range}",
+                            org.apache.xerces.*;resolution:=optional,
+                            org.springframework.*;resolution:=optional,
+                            org.w3c.*;version="${org.w3c.version}",
+                            org.xml.sax.*;version="${org.xml.sax.version}",
+                            com.ibm.icu.*;resolution:=optional,
+                            org.apache.xml.*;resolution:=optional,
+                            org.doomdark.uuid;resolution:=optional,
+                        </Import-Package>
+                        <Embed-Dependency>nekohtml,openxri-syntax,openxri-client;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <openid4java.version>1.0.0</openid4java.version>
+        <openid4java.export.version>1.0.0</openid4java.export.version>
+        <net.sourceforge.nekohtml.version>1.9.13</net.sourceforge.nekohtml.version>
+        <code.google.imp.pkg.version.range>[1.3.0,1.4.0)</code.google.imp.pkg.version.range>
+        <javax.crypto.version>0.0.0</javax.crypto.version>
+        <javax.net.version>0.0.0</javax.net.version>
+        <javax.servlet.imp.pkg.version.range>[2.6.0,2.7.0)</javax.servlet.imp.pkg.version.range>
+        <javax.xml.version>0.0.0</javax.xml.version>
+        <net.sf.ehcache.imp.pkg.version.range>[1.5,1.6)</net.sf.ehcache.imp.pkg.version.range>
+        <commons.codec.imp.pkg.version.range>[1.4.0,2.0.0)</commons.codec.imp.pkg.version.range>
+        <commons.logging.imp.pkg.version.range>[1.2.0,1.3.0)</commons.logging.imp.pkg.version.range>
+        <http.client.imp.pkg.version.range>[4.5,5.0)</http.client.imp.pkg.version.range>
+        <http.imp.pkg.version.range>[4.3.3, 5.0.0)</http.imp.pkg.version.range>
+        <org.w3c.version>0.0.0</org.w3c.version>
+        <org.xml.sax.version>0.0.0</org.xml.sax.version>
+        <openxri-syntax.version>1.2.0</openxri-syntax.version>
+        <openxri-client.version>1.2.0</openxri-client.version>
+        <nekohtml.version>1.9.10</nekohtml.version>
+    </properties>
+
+</project>

--- a/yubico-webauthn/1.10.0.wso2v1/pom.xml
+++ b/yubico-webauthn/1.10.0.wso2v1/pom.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.yubico.webauthn</groupId>
+    <artifactId>yubico-webauthn</artifactId>
+    <packaging>bundle</packaging>
+    <version>1.10.0.wso2v1</version>
+    <name>WSO2 Carbon Orbit - Yubico Webauthn</name>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.yubico</groupId>
+            <artifactId>webauthn-server-core</artifactId>
+            <version>${com.yubico.webauthn.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-cbor</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            com.upokecenter,
+                            COSE
+                        </Private-Package>
+                        <Import-Package>
+                            !com.yubico.webauthn.*,
+                            !com.yubico.internal.*,
+                            com.fasterxml.jackson.core.*; version="${fasterxml.jackson.version.range}",
+                            com.fasterxml.jackson.databind.*; version="${fasterxml.jackson.version.range}",
+                            com.fasterxml.jackson.annotation.*; version="${fasterxml.jackson.version.range}",
+                            com.fasterxml.jackson.datatype.jdk8.*; version="${fasterxml.jackson.version.range}",
+                            com.fasterxml.jackson.dataformat.cbor.*; version="${fasterxml.jackson.version.range}",
+                            org.apache.commons.logging.*; version="${apache.commons.logging.version.range}",
+                            org.slf4j.*; version="${slf4j.version.range}",
+                            com.google.common.base.*; version="${guava.osgi.version.range}",
+                            com.google.common.collect.*; version="${guava.osgi.version.range}",
+                            com.google.common.base.*;version="${guava.osgi.version.range}",
+                            com.google.common.util.concurrent.*;version="${guava.osgi.version.range}",
+                            com.google.common.collect.*;version="${guava.osgi.version.range}",
+                            com.google.common.primitives.*;version="${guava.osgi.version.range}",
+                            com.google.common.cache.*;version="${guava.osgi.version.range}",
+                            com.google.common.io.*;version="${guava.osgi.version.range}",
+                            org.apache.commons.codec.*;version="${apache.commons.codec.version.range}",
+                            org.apache.commons.logging.*;version="${apache.commons.logging.version.range}",
+                            org.apache.http.*;version="${apache.http.client.version.range}",
+                            org.bouncycastle.*; version="${bouncycastle.version.range}"
+                        </Import-Package>
+                        <Export-Package>
+                            com.yubico.webauthn.*; version=${com.yubico.webauthn.version},
+                            com.yubico.webauthn.data.*; version=${com.yubico.webauthn.version},
+                            com.yubico.webauthn.exception.*; version=${com.yubico.webauthn.version},
+                            com.yubico.internal.util.*; version=${com.yubico.webauthn.version}
+                        </Export-Package>
+                        <Embed-Dependency>*;scope=compile|runtime;inline=false;</Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <properties>
+        <com.yubico.webauthn.version>1.10.0</com.yubico.webauthn.version>
+        <guava.osgi.version.range>[18.0.0,30.0.0)</guava.osgi.version.range>
+        <apache.commons.codec.version.range>[1.1.0, 2.0.0)</apache.commons.codec.version.range>
+        <apache.commons.logging.version.range>[1.1.0, 2.0.0)</apache.commons.logging.version.range>
+        <apache.http.client.version.range>[4.5.0, 5.0.0)</apache.http.client.version.range>
+        <bouncycastle.version.range>[1.50.0, 2.0.0)</bouncycastle.version.range>
+        <fasterxml.jackson.version.range>[2.9.5, 3.0.0)</fasterxml.jackson.version.range>
+        <slf4j.version.range>[1.6.1, 2.0.0)</slf4j.version.range>
+    </properties>
+
+</project>

--- a/yubico-webauthn/1.10.1.wso2v1/pom.xml
+++ b/yubico-webauthn/1.10.1.wso2v1/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.wso2.orbit.yubico.webauthn</groupId>
     <artifactId>yubico-webauthn</artifactId>
     <packaging>bundle</packaging>
-    <version>1.10.0.wso2v1</version>
+    <version>1.10.1.wso2v1</version>
     <name>WSO2 Carbon Orbit - Yubico Webauthn</name>
     <url>http://wso2.org</url>
 
@@ -80,6 +80,14 @@
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -150,7 +158,7 @@
     </distributionManagement>
 
     <properties>
-        <com.yubico.webauthn.version>1.10.0</com.yubico.webauthn.version>
+        <com.yubico.webauthn.version>1.10.1</com.yubico.webauthn.version>
         <guava.osgi.version.range>[18.0.0,30.0.0)</guava.osgi.version.range>
         <apache.commons.codec.version.range>[1.1.0, 2.0.0)</apache.commons.codec.version.range>
         <apache.commons.logging.version.range>[1.1.0, 2.0.0)</apache.commons.logging.version.range>


### PR DESCRIPTION
## Purpose
1. Support latest yubico version.
2. Latest yubico depending on http client version higher than 4.5 hence packing the httpclient version 4.5.13 instead of httpclient 4.3.6 (4.5.13 is already available in the master branch)
2. httpclient is depending on http core. http client 4.5.13 expecting http core version to be higher than 4.4. Therefore updated the httpcore version to 4.4.14.(4.4.14 is already available in the master branch)
3. httpmime is depending on httpcore. Therefore updated httpmime from 4.3.1 to 4.5.13
4. Updated openid4java since old openidjava is expecting old versions of httpclient and httpcore(updated httpclient, httpcore version to the latest one)