### PR TITLE
Update esapi version in opensaml

### DIFF
--- a/opensaml/3.3.1.wso2v2/pom.xml
+++ b/opensaml/3.3.1.wso2v2/pom.xml
@@ -1111,7 +1111,7 @@
 
         <joda-time.orbit.version>2.9.4.wso2v1</joda-time.orbit.version>
         <joda-time.orbit.version.range>[2.9.4,3.0.0)</joda-time.orbit.version.range>
-        <esapi.version>2.1.0.1</esapi.version>
+        <esapi.version>2.2.3.1</esapi.version>
 
         <!--OpenSAML3 Orbit Version-->
         <opensaml.orbit.version>3.3.1.wso2v2</opensaml.orbit.version>

--- a/opensaml/3.3.1.wso2v3/pom.xml
+++ b/opensaml/3.3.1.wso2v3/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
   ~
   ~  WSO2 Inc. licenses this file to you under the Apache License,
   ~  Version 2.0 (the "License"); you may not use this file except

--- a/opensaml/3.3.1.wso2v3/pom.xml
+++ b/opensaml/3.3.1.wso2v3/pom.xml
@@ -1111,10 +1111,10 @@
 
         <joda-time.orbit.version>2.9.4.wso2v1</joda-time.orbit.version>
         <joda-time.orbit.version.range>[2.9.4,3.0.0)</joda-time.orbit.version.range>
-        <esapi.version>2.1.0.1</esapi.version>
+        <esapi.version>2.2.3.1</esapi.version>
 
         <!--OpenSAML3 Orbit Version-->
-        <opensaml.orbit.version>3.3.1.wso2v2</opensaml.orbit.version>
+        <opensaml.orbit.version>3.3.1.wso2v3</opensaml.orbit.version>
 
         <javax.crypto.version>[0.0.0,1.0.0)</javax.crypto.version>
         <javax.net.version>[0.0.0,1.0.0)</javax.net.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <module>swagger-request-validator/2.12.1.wso2v1</module>
         <module>swagger-request-validator/2.12.1.wso2v2</module>
         <module>olingo-server/4.5.0wso2v1</module>
-        <module>opensaml/3.3.1.wso2v2</module>
+        <module>opensaml/3.3.1.wso2v3</module>
     </modules>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
         <module>swagger-request-validator/2.12.1.wso2v1</module>
         <module>swagger-request-validator/2.12.1.wso2v2</module>
         <module>olingo-server/4.5.0wso2v1</module>
+        <module>opensaml/3.3.1.wso2v2</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Update the esapi version embedded in opensaml to non-vulnerable v2.2.3.1 
Related to https://github.com/wso2/product-is/issues/12489