### PR TITLE
Add ua-parser 1.5.2.wso2v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         <module>swagger-request-validator/2.12.1.wso2v2</module>
         <module>olingo-server/4.5.0wso2v1</module>
         <module>opensaml/3.3.1.wso2v3</module>
+        <module>ua-parser/1.5.2.wso2v1</module>
     </modules>
 
     <build>

--- a/ua-parser/1.5.2.wso2v1/pom.xml
+++ b/ua-parser/1.5.2.wso2v1/pom.xml
@@ -1,0 +1,88 @@
+<!--
+ ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ua.parser.wso2</groupId>
+    <artifactId>ua-parser</artifactId>
+    <packaging>bundle</packaging>
+    <name>ua-parser-wso2</name>
+    <version>1.5.2.wso2v1</version>
+    <description>
+        This bundle represents ua-parser 1.5.2
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>maven-twttr</id>
+            <name>Twitter Public Maven Repo</name>
+            <url>http://maven.twttr.com</url>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.ua-parser</groupId>
+            <artifactId>uap-java</artifactId>
+            <version>${ua-parser.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>1.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Bundle-Vendor>WSO2 Inc</Bundle-Vendor>
+                        <Bundle-Description>${project.description}</Bundle-Description>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            ua_parser.*;version="${project.version}",
+                            org.yaml.snakeyaml.*;version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.apache.commons.collections4.map;version="[4.0.0,4.5.0)"
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <ua-parser.version>1.5.2</ua-parser.version>
+    </properties>
+
+</project>


### PR DESCRIPTION
## Purpose

Resolves - [#12780](https://github.com/wso2/product-is/issues/12780)

> In the limiting active user session feature, it displays the current active sessions with browser family in the browser column. When we have a logged in session with Microsoft edge, it shows the browser as chrome.
> In this feature, we used the ua-parser library to extract these user-agent details. But the mentioned issue is already identified in the ua-parser 1.3.0 and it has been fixed and released as a new version. So issue is fixed by upgrading to ua-parser 1.5.2.