### PR TITLE
Add new swagger inflector and waffle bundles

### DIFF
--- a/swagger-inflector/2.0.5.wso2v2/pom.xml
+++ b/swagger-inflector/2.0.5.wso2v2/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.io.swagger</groupId>
+    <artifactId>swagger-inflector-oas3</artifactId>
+    <version>2.0.5.wso2v2</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - swagger-inflector (io.swagger)</name>
+    <description>
+        This bundle exports packages from swagger-inflector libraries of io.swagger
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-inflector</artifactId>
+            <version>${swagger.inflector.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.swagger.oas.inflector.*;version="${swagger.inflector.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            javax.servlet; version="${javax.servlet.import.pkg.version.range}",
+                            javax.servlet.http; version="${javax.servlet.import.pkg.version.range}",
+                            javax.xml.bind.annotation; version="${javax.xml.bind.imp.pkg.version}",
+                            org.slf4j; version="${slf4j.imp.pkg.version.range}",
+                            org.joda.time; version="${joda.time.imp.pkg.version.range}",
+                            org.apache.commons.lang3; version="${apache.commons.lang3.imp.pkg.version.range}",
+                            org.apache.commons.lang; version="${apache.commons.lang.imp.pkg.version.range}",
+                            javax.xml.stream; version="${javax.xml.stream.imp.pkg.version.range}",
+                            io.swagger.v3.core.filter; version="${swagger.imp.pkg.version.range}",
+                            io.swagger.v3.core.util; version="${swagger.imp.pkg.version.range}",
+                            io.swagger.v3.parser; version="${swagger.imp.pkg.version.range}",
+                            io.swagger.v3.parser.core.models; version="${swagger.imp.pkg.version.range}",
+                            io.swagger.v3.parser.util; version="${swagger.imp.pkg.version.range}",
+                            io.swagger.v3.oas.models; version="${swagger.imp.pkg.version.range}",
+                            com.google.common.io; version="${google.common.io.imp.pkg.version.range}",
+                            com.github.fge.jsonschema.main; version="${fge.jsonschema.main.imp.pkg.version.range}",
+                            com.github.fge.jsonschema.core.report; version="${fge.jsonschema.core.imp.pkg.version.range}",
+                            com.github.fge.jsonschema.core.exceptions; version="${fge.jsonschema.core.imp.pkg.version.range}",
+                            com.fasterxml.jackson.databind.type; version="${jackson.databind.imp.pkg.version.range}",
+                            com.fasterxml.jackson.databind.node; version="${jackson.databind.imp.pkg.version.range}",
+                            com.fasterxml.jackson.databind.module; version="${jackson.databind.imp.pkg.version.range}",
+                            com.fasterxml.jackson.databind.annotation; version="${jackson.databind.imp.pkg.version.range}",
+                            com.fasterxml.jackson.databind; version="${jackson.databind.imp.pkg.version.range}",
+                            com.fasterxml.jackson.core; version="${jackson.databind.imp.pkg.version.range}",
+                            com.fasterxml.jackson.annotation; version="${jackson.databind.imp.pkg.version.range}",
+                            com.fasterxml.jackson.dataformat.xml; version="${jackson.databind.imp.pkg.version.range}",
+                            com.fasterxml.jackson.jaxrs.json; version="${jackson.databind.imp.pkg.version.range}",
+                            com.fasterxml.jackson.jaxrs.xml; version="${jackson.databind.imp.pkg.version.range}",
+                            javax.inject; version="${javax.inject.imp.pkg.version.range}",
+                            javax.ws.rs; version="${javax.ws.rs.imp.pkg.version.range}",
+                            javax.ws.rs.container; version="${javax.ws.rs.imp.pkg.version.range}",
+                            javax.ws.rs.core; version="${javax.ws.rs.imp.pkg.version.range}",
+                            javax.ws.rs.ext; version="${javax.ws.rs.imp.pkg.version.range}",
+                            org.apache.commons.io; version="${commons.io.imp.pkg.version.range}",
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <javax.servlet.import.pkg.version.range>[2.6.0,3.0.0)</javax.servlet.import.pkg.version.range>
+        <swagger.inflector.version>2.0.5</swagger.inflector.version>
+        <swagger.imp.pkg.version.range>[2.0.0,3.0.0]</swagger.imp.pkg.version.range>
+        <javax.servlet.imp.pkg.version.range>[2.6.0,3.0.0]</javax.servlet.imp.pkg.version.range>
+        <slf4j.imp.pkg.version.range>[1.7.0,2.0.0]</slf4j.imp.pkg.version.range>
+        <javax.xml.bind.imp.pkg.version>0.0.0</javax.xml.bind.imp.pkg.version>
+        <joda.time.imp.pkg.version.range>[2.9.0,3.0.0)</joda.time.imp.pkg.version.range>
+        <apache.commons.lang3.imp.pkg.version.range>[3.4.0,4.0.0)</apache.commons.lang3.imp.pkg.version.range>
+        <apache.commons.lang.imp.pkg.version.range>[2.6.0,3.0.0)</apache.commons.lang.imp.pkg.version.range>
+        <javax.xml.stream.imp.pkg.version.range>[1.0.1,2.0.0)</javax.xml.stream.imp.pkg.version.range>
+        <google.common.io.imp.pkg.version.range>[27.0.0,32.0.0)</google.common.io.imp.pkg.version.range>
+        <fge.jsonschema.main.imp.pkg.version.range>[2.2.0,3.0.0)</fge.jsonschema.main.imp.pkg.version.range>
+        <fge.jsonschema.core.imp.pkg.version.range>[1.2.0,2.0.0)</fge.jsonschema.core.imp.pkg.version.range>
+        <jackson.databind.imp.pkg.version.range>[2.9.0,3.0.0)</jackson.databind.imp.pkg.version.range>
+        <javax.inject.imp.pkg.version.range>[1.0.0,2.0.0)</javax.inject.imp.pkg.version.range>
+        <javax.ws.rs.imp.pkg.version.range>[2.0.0,3.0.0)</javax.ws.rs.imp.pkg.version.range>
+        <commons.io.imp.pkg.version.range>[2.4.0,3.0.0)</commons.io.imp.pkg.version.range>
+    </properties>
+</project>

--- a/waffle/1.6.wso2v7/pom.xml
+++ b/waffle/1.6.wso2v7/pom.xml
@@ -1,0 +1,123 @@
+<!--
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.github.dblock.waffle</groupId>
+    <artifactId>waffle-jna</artifactId>
+    <packaging>bundle</packaging>
+    <name>waffle.wso2</name>
+    <version>1.6.wso2v7</version>
+    <description>
+        This bundle will represent waffle-jna 1.6
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.dblock.waffle</groupId>
+            <artifactId>waffle-jna</artifactId>
+            <version>${waffle.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.github.dblock.waffle</groupId>
+            <artifactId>waffle-tomcat7</artifactId>
+            <version>${waffle.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Bundle-Vendor>WSO2 Inc</Bundle-Vendor>
+                        <Bundle-Description>${project.description}</Bundle-Description>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            waffle.*;version="${project.version}",
+                            com.sun.jna.*;version="${project.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            com.google.common.base;resolution:=optional;version="${com.google.common.version}",
+                            com.google.common.cache;resolution:=optional;version="${com.google.common.version}",
+                            com.google.common.io;resolution:=optional;version="${com.google.common.version}",
+                            javax.security.auth;version="${javax.security.version}",
+                            javax.security.auth.callback;version="${javax.security.version}",
+                            javax.security.auth.login;version="${javax.security.version}",
+                            javax.security.auth.spi;version="${javax.security.version}",
+                            javax.servlet;version="${javax.servlet.version}",
+                            javax.servlet.http;version="${javax.servlet.version}",
+                            javax.swing;version="${javax.swing.version}",
+                            javax.swing.text;version="${javax.swing.version}",
+                            javax.xml.parsers;version="${javax.xml.version}",
+                            javax.xml.transform;version="${javax.xml.version}",
+                            javax.xml.transform.dom;version="${javax.xml.version}",
+                            javax.xml.transform.stream;version="${javax.xml.version}",
+                            org.apache.catalina;resolution:=optional,
+                            org.apache.catalina.authenticator;resolution:=optional,
+                            org.apache.catalina.connector;resolution:=optional,
+                            org.apache.catalina.deploy;resolution:=optional,
+                            org.apache.catalina.realm;resolution:=optional,
+                            org.w3c.dom;version="${org.w3c.version}",
+                            org.slf4j.*;version="${org.slf4j.version}"
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <waffle.version>1.6</waffle.version>
+        <org.slf4j.version>[1.6.0,2.0.0)</org.slf4j.version>
+        <com.google.common.version>[27.0.0,32.0.0)</com.google.common.version>
+        <javax.servlet.version>[2.6.0,3.0.0)</javax.servlet.version>
+        <org.w3c.version>0.0.0</org.w3c.version>
+        <javax.swing.version>0.0.0</javax.swing.version>
+        <javax.xml.version>0.0.0</javax.xml.version>
+        <javax.security.version>0.0.0</javax.security.version>
+    </properties>
+
+
+</project>


### PR DESCRIPTION
## Purpose
This PR adds new bundles for swagger-inflector (`2.0.5.wso2v2`) and waffle (`1.6.wso2v7`). This is to upgrade the guava version.