### PR TITLE
Upgrade owasp esapi library from 2.1.0.1 to 2.4.0.0

### DIFF
--- a/opensaml/2.6.6.wso2v3/pom.xml
+++ b/opensaml/2.6.6.wso2v3/pom.xml
@@ -323,7 +323,7 @@
         <joda-time.orbit.version.range>[2.8.2,3.0.0)</joda-time.orbit.version.range>
         <xmltooling.version>1.4.4</xmltooling.version>
         <openws.version>1.5.4</openws.version>
-        <esapi.version>2.1.0.1</esapi.version>
+        <esapi.version>2.4.0.0</esapi.version>
         <opensaml.orbit.version>2.6.6.wso2v3</opensaml.orbit.version>
         <javax.crypto.version>[0.0.0,1.0.0)</javax.crypto.version>
         <javax.net.version>[0.0.0,1.0.0)</javax.net.version>

--- a/opensaml/3.3.1.wso2v1/pom.xml
+++ b/opensaml/3.3.1.wso2v1/pom.xml
@@ -1111,7 +1111,7 @@
 
         <joda-time.orbit.version>2.9.4.wso2v1</joda-time.orbit.version>
         <joda-time.orbit.version.range>[2.9.4,3.0.0)</joda-time.orbit.version.range>
-        <esapi.version>2.1.0.1</esapi.version>
+        <esapi.version>2.4.0.0</esapi.version>
 
         <!--OpenSAML3 Orbit Version-->
         <opensaml.orbit.version>3.3.1.wso2v1</opensaml.orbit.version>


### PR DESCRIPTION
## Purpose
> Upgrade owasp esapi library from 2.1.0.1 to 2.4.0.0