### PR TITLE
Upgrade google clients and quartz

### DIFF
--- a/google-api-client/1.33.1.wso2v1/pom.xml
+++ b/google-api-client/1.33.1.wso2v1/pom.xml
@@ -1,0 +1,94 @@
+<!--
+ ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.google.api-client</groupId>
+    <artifactId>google-api-client</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Google API Client</name>
+    <version>1.33.1.wso2v1</version>
+    <description>
+        This bundle will represent google-api-client 1.33.1
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>${google-api-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.google.api.client.googleapis.*;version="${google-api-client.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !com.google.api.client.googleapis.*,
+                            com.google.api.client.auth.oauth2;version="${google-oauth-client.orbit.imp.pkg.version}",
+                            com.google.api.client.auth.openidconnect;version="${google-oauth-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.apache.v2;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.javanet;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.json;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json.webtoken;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util.store;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.common.base;version="${google.guava.orbit.imp.pkg.version}",
+                            com.google.common.collect;version="${google.guava.orbit.imp.pkg.version}"
+                            com.google.common.io;version="${google.guava.orbit.imp.pkg.version}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <google-api-client.version>1.33.1</google-api-client.version>
+        <google-oauth-client.orbit.imp.pkg.version>[1.33.1,1.34.0)</google-oauth-client.orbit.imp.pkg.version>
+        <google-http-client.orbit.imp.pkg.version>[1.41.2,1.42.0)</google-http-client.orbit.imp.pkg.version>
+        <google.guava.orbit.imp.pkg.version>[31.0,32)</google.guava.orbit.imp.pkg.version>
+    </properties>
+</project>

--- a/google-http-client/1.41.2.wso2v1/pom.xml
+++ b/google-http-client/1.41.2.wso2v1/pom.xml
@@ -1,0 +1,135 @@
+<!--
+ ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.google.http-client</groupId>
+    <artifactId>google-http-client</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Google http Client</name>
+    <version>1.41.2.wso2v1</version>
+    <description>
+        This bundle will represent google-http-client 1.41.2
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>${google-http-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client-jackson2</artifactId>
+            <version>${google-http-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.google.api.client.http.*;version="${google-http-client.version}",
+                            com.google.api.client.json.*;version="${google-http-client.version}",
+                            com.google.api.client.repackaged.*;version="${google-http-client.version}",
+                            com.google.api.client.util.*;version="${google-http-client.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !com.google.api.client.http.*,
+                            !com.google.api.client.json.*,
+                            !com.google.api.client.repackaged.*,
+                            !com.google.api.client.util.*,
+                            com.fasterxml.jackson.core;version="${jackson-core.orbit.imp.pkg.version}",
+                            com.google.api.client.auth.oauth2;version="${google-oauth-client.orbit.imp.pkg.version}",
+                            com.google.common.base;version="${google-guava.imp.pkg.version}",
+                            com.google.common.collect;version="${google-guava.imp.pkg.version}",
+                            com.google.common.io;version="${google-guava.imp.pkg.version}",
+                            com.google.common.util.concurrent;version="${google-guava.imp.pkg.version}",
+                            org.apache.http;version="${httpcore.orbit.imp.pkg.version}",
+                            org.apache.http.entity;version="${httpcore.orbit.imp.pkg.version}",
+                            org.apache.http.params;version="${httpcore.orbit.imp.pkg.version}",
+                            org.apache.http.client;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.client.methods;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn.params;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn.routing;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn.scheme;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn.ssl;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.impl.client;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.impl.conn;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.impl.conn.tsccm;version="${httpclient.orbit.imp.pkg.version}",
+                            javax.annotation,
+                            javax.net.ssl
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <google-http-client.version>1.41.2</google-http-client.version>
+        <jackson-core.orbit.imp.pkg.version>[2.6.0,3.0.0)</jackson-core.orbit.imp.pkg.version>
+        <google-oauth-client.orbit.imp.pkg.version>[1.33.1,1.34.0)</google-oauth-client.orbit.imp.pkg.version>
+        <google-guava.imp.pkg.version>[31.0,32)</google-guava.imp.pkg.version>
+        <httpcore.orbit.imp.pkg.version>[4.4.15,4.5.0)</httpcore.orbit.imp.pkg.version>
+        <httpclient.orbit.imp.pkg.version>[4.5.13,4.6.0)</httpclient.orbit.imp.pkg.version>
+    </properties>
+
+</project>

--- a/google-oauth-client/1.33.1.wso2v1/pom.xml
+++ b/google-oauth-client/1.33.1.wso2v1/pom.xml
@@ -1,0 +1,126 @@
+<!--
+ ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.google.oauth-client</groupId>
+    <artifactId>google-oauth-client</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Google OAuth Client</name>
+    <version>1.33.1.wso2v1</version>
+    <description>
+        This bundle will represent google-oauth-client 1.33.1
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client</artifactId>
+            <version>${google-oauth-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client-java6</artifactId>
+            <version>${google-oauth-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client-jetty</artifactId>
+            <version>${google-oauth-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.google.api.client.auth.*;version="${google-oauth-client.version}",
+                            com.google.api.client.extensions.java6.auth.oauth2;version="${google-oauth-client.version}",
+                            com.google.api.client.extensions.jetty.auth.oauth2;version="${google-oauth-client.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !com.google.api.client.auth.*,
+                            !com.google.api.client.extensions.java6.auth.oauth2,
+                            !com.google.api.client.extensions.jetty.auth.oauth2,
+                            com.google.api.client.http;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util.escape;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util.store;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json.webtoken;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.common.io;version="${google-guava.imp.pkg.version}",
+                            javax.servlet.http;version="${javax.servlet.imp.pkg.version}",
+                            javax.crypto,
+                            javax.crypto.spec
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <google-oauth-client.version>1.33.1</google-oauth-client.version>
+        <google-http-client.orbit.imp.pkg.version>[1.41,2)</google-http-client.orbit.imp.pkg.version>
+        <google-guava.imp.pkg.version>[31.0,32)</google-guava.imp.pkg.version>
+        <javax.servlet.imp.pkg.version>[2.6, 3)</javax.servlet.imp.pkg.version>
+    </properties>
+
+</project>

--- a/quartz/2.3.2.wso2v1/pom.xml
+++ b/quartz/2.3.2.wso2v1/pom.xml
@@ -1,0 +1,84 @@
+<!--
+~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~
+~ WSO2 Inc. licenses this file to you under the Apache License,
+~ Version 2.0 (the "License"); you may not use this file except
+~ in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing,
+~ software distributed under the License is distributed on an
+~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~ KIND, either express or implied.  See the License for the
+~ specific language governing permissions and limitations
+~ under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.quartz-scheduler.wso2</groupId>
+    <artifactId>quartz</artifactId>
+    <packaging>bundle</packaging>
+    <name>quartz.wso2</name>
+    <version>2.3.2.wso2v1</version>
+    <description>
+        org.quartz. This bundle will export packages from quartz.jar
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 Internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 Internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>1.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.quartz.*;version="2.3.2"
+                        </Export-Package>
+			            <Import-Package/>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+


### PR DESCRIPTION
## Purpose
This PR will add the following to orbit,
- google-oauth-client 1.33.1
- google-api-client 1.33.1
- google-http-client 1.41.2
- quartz 2.3.2