### PR TITLE
Add new orbit bundle for jstl

### DIFF
--- a/jstl/1.2.1.wso2v3/pom.xml
+++ b/jstl/1.2.1.wso2v3/pom.xml
@@ -1,0 +1,73 @@
+<!--
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.javax.servlet.jsp.jstl</groupId>
+    <artifactId>jstl</artifactId>
+    <version>1.2.1.wso2v3</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Javax servlet bundle</name>
+    <description>Javax Servlet API</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.servlet.jsp.jstl</artifactId>
+            <version>${version.jstl.glassfish}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet.jsp.jstl</groupId>
+            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+            <version>${version.jstl}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package></Private-Package>
+                        <Export-Package>
+                            org.apache.taglibs.standard.*;version="${exp.pkg.version.org.apache.taglibs.standard}";-split-package:=merge-first,
+                            javax.servlet.jsp.jstl.*;version="${exp.pkg.version.javax.servlet.jsp.jstl}";-split-package:=merge-first
+                        </Export-Package>
+                        <Import-Package>*;resolution:=optional</Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <version.jstl>1.2.1</version.jstl>
+        <version.jstl.glassfish>1.2.5</version.jstl.glassfish>
+        <orbit.version.jstl>1.2.1.wso2v3</orbit.version.jstl>
+        <exp.pkg.version.javax.servlet.jsp.jstl>1.2.1</exp.pkg.version.javax.servlet.jsp.jstl>
+        <exp.pkg.version.org.apache.taglibs.standard>1.2.5</exp.pkg.version.org.apache.taglibs.standard>
+        <imp.pkg.version.javax.servlet.jsp.jstl>[1.2.1, 1.3.0)</imp.pkg.version.javax.servlet.jsp.jstl>
+    </properties>
+</project>


### PR DESCRIPTION
This PR adds the new orbit bundle `jstl_1.2.1.wso2v3`. Here, the Apache Standard Taglibs version is upgraded to 1.2.5.