### PR TITLE
Upgrade jetty version to 9.4.48.v20220622

### DIFF
--- a/solr/8.11.1.wso2v1/pom.xml
+++ b/solr/8.11.1.wso2v1/pom.xml
@@ -224,7 +224,7 @@
         <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <http.version>[4.3.0,4.4.0)</http.version>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <rrd4j.version>3.8.1</rrd4j.version>
         <calcite.version>1.26.0</calcite.version>
         <version.locationtech.spatial4j>0.8</version.locationtech.spatial4j>


### PR DESCRIPTION
## Purpose
> Bump Jetty-HTTP version in solr_8.11.1.wso2v1 to 9.4.48.v20220622