### PR TITLE
Add poi-ooxml 5.2.3 wso2 bundle

### DIFF
--- a/poi-ooxml/5.2.3.wso2v1/pom.xml
+++ b/poi-ooxml/5.2.3.wso2v1/pom.xml
@@ -1,0 +1,115 @@
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.apache.poi</groupId>
+    <artifactId>poi-ooxml</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - POI ooxml</name>
+    <version>5.2.3.wso2v1</version>
+    <description>
+        This bundle will export packages from apache poi ooxml and poi ooxml schemas
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>${version.poi-ooxml}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml-schemas</artifactId>
+            <version>${version.poi-ooxml-schemas}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
+                        <Fragment-Host>poi</Fragment-Host>
+                        <Export-Package>
+                            !org.apache.commons.codec.*,
+                            org.apache.poi.*;version="${project.version}";-split-package:=merge-last,
+                            org.openxmlformats.schemas.*;version="${project.version}",
+                            schemaorg_apache_xmlbeans.*;version="${project.version}",
+                            schemasMicrosoftComOfficeExcel.*;version="${project.version}",
+                            schemasMicrosoftComOfficeOffice.*;version="${project.version}",
+                            schemasMicrosoftComVml.*;version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            !javax.crypto.*,
+                            !javax.imageio.*,
+                            !javax.swing.*,
+                            !javax.xml.*,
+                            !junit.*,
+                            !org.apache.commons.*,
+                            !org.apache.poi.*,
+                            !org.apache.xmlbeans.*,
+                            !org.dom4j.*,
+                            !org.openxmlformats.schemas.*,
+                            !org.w3c.dom.*,
+                            !org.xml.sax.*,
+                            !schemaorg_apache_xmlbeans.*,
+                            !schemasMicrosoftComOfficeExcel.*,
+                            !schemasMicrosoftComOfficeOffice.*,
+                            !schemasMicrosoftComOfficePowerpoint.*,
+                            !schemasMicrosoftComOfficeWord.*,
+                            !schemasMicrosoftComVml.*,
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <version.poi-ooxml>5.2.3</version.poi-ooxml>
+        <version.poi-ooxml-schemas>4.1.2</version.poi-ooxml-schemas>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose
- Adding poi-ooxml latest version 5.2.3[1] as an orbit bundle
- Referrence[2]

[1] https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml/5.2.3
[2] https://github.com/wso2/orbit/blob/master/poi-ooxml/3.9.0.wso2v3/pom.xml