### PR TITLE
Add orbit bundles for kafka schema registry and kafka avro serializer

### DIFF
--- a/kafka-avro-serializer/7.3.1.wso2v1/pom.xml
+++ b/kafka-avro-serializer/7.3.1.wso2v1/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.confluent.wso2</groupId>
+    <artifactId>kafka-avro-serializer</artifactId>
+    <version>7.3.1.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Kafka Avro Serializer</name>
+    <description>
+        This bundle will export packages from Kafka Avro Serializer library of io.confluent
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+        <repository>
+            <id>confluent</id>
+            <name>Confluent Repository</name>
+            <url>https://packages.confluent.io/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+<!--    <&#45;&#45;org.apache.kafka.common.serialization; version="0.0.0" <kafka_clients_5.5.0_ccs_1.0.0 [112]&ndash;&gt;-->
+
+
+    <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>${kafka-avro-serializer.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.confluent.kafka.formatter;version="${export.pkg.version.kafka-avro-serializer}",
+                            io.confluent.kafka.serializers;version="${export.pkg.version.kafka-avro-serializer}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            org.apache.kafka.common.serialization,
+                            io.confluent.kafka.serializers.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Include-Resource>
+                            {maven-resources}
+                        </Include-Resource>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <kafka-avro-serializer.version>7.3.1</kafka-avro-serializer.version>
+        <export.pkg.version.kafka-avro-serializer>7.3.1.wso2v1</export.pkg.version.kafka-avro-serializer>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/kafka-avro-serializer/7.3.1.wso2v1/pom.xml
+++ b/kafka-avro-serializer/7.3.1.wso2v1/pom.xml
@@ -68,8 +68,6 @@
             <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
-<!--    <&#45;&#45;org.apache.kafka.common.serialization; version="0.0.0" <kafka_clients_5.5.0_ccs_1.0.0 [112]&ndash;&gt;-->
-
 
     <dependencies>
         <dependency>

--- a/kafka-schema-registry-client/7.3.1.wso2v1/pom.xml
+++ b/kafka-schema-registry-client/7.3.1.wso2v1/pom.xml
@@ -68,7 +68,6 @@
             <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
-<!--    <&#45;&#45;org.apache.kafka.common.serialization; version="0.0.0" <kafka_clients_5.5.0_ccs_1.0.0 [112]&ndash;&gt;-->
 
 
     <dependencies>

--- a/kafka-schema-registry-client/7.3.1.wso2v1/pom.xml
+++ b/kafka-schema-registry-client/7.3.1.wso2v1/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.confluent.wso2</groupId>
+    <artifactId>kafka-schema-registry-client</artifactId>
+    <version>7.3.1.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Kafka Schema Registry Client</name>
+    <description>
+        This bundle will export packages from Kafka Schema Registry client of io.confluent
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+        <repository>
+            <id>confluent</id>
+            <name>Confluent Repository</name>
+            <url>https://packages.confluent.io/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+<!--    <&#45;&#45;org.apache.kafka.common.serialization; version="0.0.0" <kafka_clients_5.5.0_ccs_1.0.0 [112]&ndash;&gt;-->
+
+
+    <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
+            <version>${kafka-shema-registry-client.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.confluent.kafka.schemaregistry.avro;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.client.rest;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.client.rest.entities;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.client.rest.entities.requests;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.client.rest.exceptions;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.client.rest.utils;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.client;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.client.security.basicauth;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.client.security;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.client.security.bearerauth;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.utils;version="${export.pkg.version.kafka-schema-registry-client}",
+                            io.confluent.kafka.schemaregistry.testutil;version="${export.pkg.version.kafka-schema-registry-client}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            org.apache.avro.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Include-Resource>
+                            {maven-resources}
+                        </Include-Resource>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <kafka-shema-registry-client.version>7.3.1</kafka-shema-registry-client.version>
+        <export.pkg.version.kafka-schema-registry-client>7.3.1.wso2v1</export.pkg.version.kafka-schema-registry-client>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose
Add bundles for kafka schema registry and kafka avro serializer in order to fix OSGI import issues

## Goals
Add new bundles 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

