### PR TITLE
Add orbit bundle for commons-net 3.9.0.wso2v1

### DIFF
--- a/commons-net/3.9.0.wso2v1/pom.xml
+++ b/commons-net/3.9.0.wso2v1/pom.xml
@@ -1,0 +1,84 @@
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.commons-net</groupId>
+    <artifactId>commons-net</artifactId>
+    <packaging>bundle</packaging>
+    <name>org.wso2.orbit.commons.net</name>
+    <version>3.9.0.wso2v1</version>
+    <description>
+        This bundle will export packages from commons-net.jar
+    </description>
+    <url>https://commons.apache.org/proper/commons-net</url>
+    <dependencies>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>${commons.net.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>4.2.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Vendor>WSO2 LLC.</Bundle-Vendor>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>org.apache.commons.net.*;version="${commons.net.version}"</Export-Package>
+                        <Private-Package></Private-Package>
+                        <Import-Package>
+                            javax.crypto;version="[0.0.0,1.0.0)",
+                            javax.crypto.spec;version="[0.0.0,1.0.0)",
+                            javax.net;version="[0.0.0,1.0.0)",
+                            javax.net.ssl;version="[0.0.0,1.0.0)"
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <commons.net.version>3.9.0</commons.net.version>
+    </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
         <module>solr/8.11.1.wso2v7</module>
         <module>webauthn4j/0.19.1.wso2v2</module>
         <module>libthrift/0.16.0.wso2v1</module>
+        <module>commons-net/3.9.0.wso2v1</module>
     </modules>
 
     <build>


### PR DESCRIPTION
## Purpose
This PR adds a new orbit bundle for commons-net `3.9.0`.

Related issue: https://github.com/wso2/api-manager/issues/1251