### PR TITLE
Bump snakeyaml version in orbit jars

### DIFF
--- a/jackson-dataformat-yaml/2.13.2.wso2v1/pom.xml
+++ b/jackson-dataformat-yaml/2.13.2.wso2v1/pom.xml
@@ -1,0 +1,138 @@
+<!--
+ ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.fasterxml.jackson.dataformat</groupId>
+    <artifactId>jackson-dataformat-yaml</artifactId>
+    <version>2.13.2.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Jackson Data Format</name>
+    <description>
+        This bundle exports packages from Jackson dataformat: csv, xml, yaml and smile.
+    </description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${com.fasterxml.jackson.dataformat.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.fasterxml.jackson.dataformat.*; version=${project.version},
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            com.fasterxml.jackson.annotation;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.core;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.core.base;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.core.format;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.core.io;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.core.json;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.core.sym;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.core.type;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.core.util;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.cfg;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.deser;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.deser.std;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.introspect;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.jsontype;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.jsontype.impl;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.module;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.ser;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.ser.impl;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.ser.std;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.type;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            com.fasterxml.jackson.databind.util;version="${com.fasterxml.jackson.dataformat.version.range}",
+                            javax.xml.bind.annotation,
+                            javax.xml.namespace,
+                            javax.xml.stream;version="${javax.xml.version.range}",
+                            javax.xml.transform,
+                            org.codehaus.stax2;version="${org.codehaus.stax2.version.range}",
+                            org.codehaus.stax2.io;version="${org.codehaus.stax2.version.range}",
+                            org.codehaus.stax2.ri;version="${org.codehaus.stax2.version.range}",
+                            org.yaml.snakeyaml;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.composer;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.constructor;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.emitter;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.error;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.events;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.extensions.compactnotation;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.introspector;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.nodes;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.parser;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.reader;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.representer;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.resolver;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.scanner;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.serializer;version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.tokens;version="${org.yaml.snakeyaml.version.range}"
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>Alfresco Maven Repository</id>
+            <url>https://maven.alfresco.com/nexus/content/groups/public/</url>
+        </repository>
+    </repositories>
+
+    <properties>
+        <com.fasterxml.jackson.dataformat.version>2.13.2</com.fasterxml.jackson.dataformat.version>
+        <com.fasterxml.jackson.dataformat.version.range>[2.2,3)</com.fasterxml.jackson.dataformat.version.range>
+        <org.codehaus.stax2.version.range>[3.1,4)</org.codehaus.stax2.version.range>
+        <org.yaml.snakeyaml.version.range>[1.23.0,2.5.0)</org.yaml.snakeyaml.version.range>
+        <javax.xml.version.range>[1.0,2)</javax.xml.version.range>
+    </properties>
+</project>

--- a/snakeyaml/2.0.0.wso2v1/pom.xml
+++ b/snakeyaml/2.0.0.wso2v1/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright (c) 2022, WSO2 LLC (http://www.wso2.com).
+  ~
+  ~  WSO2 LLC licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.orbit.org.yaml</groupId>
+    <artifactId>snakeyaml</artifactId>
+    <version>2.0.0.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>SnakeYAML</name>
+    <description>SnakeYAML orbit bundle</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${version.snake.yaml}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundleplugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.yaml.snakeyaml.*;version="${version.snake.yaml}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !org.yaml.snakeyaml.*;resolution:=optional;version="[2.0,3)"
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <version.snake.yaml>2.0</version.snake.yaml>
+        <maven.bundleplugin.version>2.5.4</maven.bundleplugin.version>
+    </properties>
+
+</project>

--- a/swagger-parser/2.0.29.wso2v2/pom.xml
+++ b/swagger-parser/2.0.29.wso2v2/pom.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ Copyright (c) 2022, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.io.swagger.v3</groupId>
+    <artifactId>swagger-parser</artifactId>
+    <version>2.0.29.wso2v2</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - swagger-parser (io.swagger)</name>
+    <description>
+        This bundle will export packages from swagger-parser libraries of io.swagger
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>${swagger-parser-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser-v2-converter</artifactId>
+            <version>${swagger-parser-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser-v3</artifactId>
+            <version>${swagger-parser-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>1.6.5</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-models</artifactId>
+            <version>1.6.5</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>2.1.12</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-models</artifactId>
+            <version>2.1.12</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.1</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson-version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson-version}</version>
+            <optional>true</optional>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.swagger.v3.*;version="${swagger-parser-version}",
+                            io.swagger.v3.parser.*;version="${swagger-parser-version}",
+                            io.swagger.v3.parser.core.*;version="${swagger-parser-version}",
+                            io.swagger.v3.parser.converter.*;version="${swagger-parser-version}",
+                            io.swagger.parser.*;version="${swagger-parser-version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.slf4j; version="${slf4j.import.version.range}",
+                            org.apache.commons.lang3.builder; version="${commons.lang.version.range}",
+                            org.apache.commons.lang3; version="${commons.lang.version.range}",
+                            javax.net.ssl; version="0.0.0",
+                            io.swagger.util; version="${io.swagger.version.range}",
+                            io.swagger.models.refs; version="${io.swagger.version.range}",
+                            io.swagger.models.properties; version="${io.swagger.version.range}",
+                            io.swagger.models.parameters; version="${io.swagger.version.range}",
+                            io.swagger.models.auth; version="${io.swagger.version.range}",
+                            io.swagger.models; version="${io.swagger.version.range}",
+                            io.swagger.v3.oas.models; version="${io.swagger.v3.version.range}",
+                            com.fasterxml.jackson.*; version="${jackson.version.range}",
+                            org.apache.commons.io;version="${commons.io.version.range}",
+                            org.apache.commons.io.comparator;version="${commons.io.version.range}",
+                            org.apache.commons.io.filefilter;version="${commons.io.version.range}",
+                            org.apache.commons.io.input;version="${commons.io.version.range}",
+                            org.apache.commons.io.output;version="${commons.io.version.range}",
+                            org.yaml.snakeyaml.*;version="${snakeyaml.version.range}",
+                            .*;resolution=optional
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Include-Resource>
+                            {maven-resources},
+                            @swagger-parser-*.jar!/META-INF/*
+                        </Include-Resource>
+                        <Embed-Dependency>
+                            commons-io;scope=compile|runtime;inline=false,
+                            swagger-models;scope=compile|runtime;inline=false,
+                            swagger-core;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <export.pkg.version.swagger-parser>2.0.29.wso2v2</export.pkg.version.swagger-parser>
+        <io.swagger.version.range>[1.6.1,1.7)</io.swagger.version.range>
+        <io.swagger.v3.version.range>[2.1.2,3.0)</io.swagger.v3.version.range>
+        <jackson.version.range>[2.7.0,3.0.0)</jackson.version.range>
+        <javax.xml.bind.version.range>[2.3.2,3.0.0)</javax.xml.bind.version.range>
+        <slf4j.import.version.range>[1.7.0, 1.8.0)</slf4j.import.version.range>
+        <commons.io.version.range>[2.6,3.0)</commons.io.version.range>
+        <commons.lang.version.range>[3.2.1,4)</commons.lang.version.range>
+        <snakeyaml.version.range>[2.0,3.00)</snakeyaml.version.range>
+        <jackson-version>2.13.1</jackson-version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <swagger-parser-version>2.0.29</swagger-parser-version>
+    </properties>
+</project>

--- a/ua-parser/1.5.2.wso2v3/pom.xml
+++ b/ua-parser/1.5.2.wso2v3/pom.xml
@@ -1,0 +1,100 @@
+<!--
+ ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ua.parser.wso2</groupId>
+    <artifactId>ua-parser</artifactId>
+    <packaging>bundle</packaging>
+    <name>ua-parser-wso2</name>
+    <version>1.5.2.wso2v3</version>
+    <description>
+        This bundle represents ua-parser 1.5.2 and the default snake-yaml version is replaced by version 2.00
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>maven-twttr</id>
+            <name>Twitter Public Maven Repo</name>
+            <url>http://maven.twttr.com</url>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.ua-parser</groupId>
+            <artifactId>uap-java</artifactId>
+            <version>${ua-parser.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snake-yaml.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>1.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Bundle-Vendor>WSO2 Inc</Bundle-Vendor>
+                        <Bundle-Description>${project.description}</Bundle-Description>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            ua_parser.*;version="${project.version}",
+                            org.yaml.snakeyaml.*;version="${snake-yaml.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.apache.commons.collections4.map;version="[4.0.0,4.5.0)"
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <ua-parser.version>1.5.2</ua-parser.version>
+        <snake-yaml.version>2.0</snake-yaml.version>
+    </properties>
+
+</project>


### PR DESCRIPTION
## Purpose

1. This PR bumps the snakeyaml and corresponding orbit dependency versions in following jars : 

- snakeyaml
- swagger-parser
- ua-parser

2. Introduces a Jackson dataformat yaml jar to update the Jackson-dataformat-yaml third party dependency with snakeyaml version 2.0. (Since at the time there's no Jackson-dataformat-yaml jar containing the snakeyaml 2.0 version)
