### PR TITLE
Upgrade the vulnarable json-smart version in jsonpath v2.6.0

### DIFF
--- a/jsonpath/2.6.0.wso2v1/pom.xml
+++ b/jsonpath/2.6.0.wso2v1/pom.xml
@@ -84,7 +84,7 @@
     </build>
     <properties>
         <jayway.jsonpath.version>2.6.0</jayway.jsonpath.version>
-        <net.mindev.jsonsmart.version>2.4.7</net.mindev.jsonsmart.version>
+        <net.mindev.jsonsmart.version>2.4.11</net.mindev.jsonsmart.version>
         <net.mindev.asm.version>1.0.2</net.mindev.asm.version>
         <commons.lang.version>2.6</commons.lang.version>
     </properties>


### PR DESCRIPTION
## Purpose

Upgrading the vulnarable json-smart version in jsonpath v2.6.0 to the latest version ( https://nvd.nist.gov/vuln/detail/CVE-2023-1370 )