### PR TITLE
Update pom changes aligning with 4.3.1.wso2v4 version

### DIFF
--- a/openapi-generator/4.3.1.wso2v5/pom.xml
+++ b/openapi-generator/4.3.1.wso2v5/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>openapi-generator</artifactId>
-            <version>4.3.1</version>
+            <version>5.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -64,6 +64,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons-io-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>0.11.0</version>
         </dependency>
     </dependencies>
 
@@ -122,7 +127,7 @@
                             dart-jaguar;version="${export.pkg.version.swagger-codegen}",
                             dart-jaguar.auth;version="${export.pkg.version.swagger-codegen}",
                             dart.auth;version="${export.pkg.version.swagger-codegen}",
-                            dart2;version="${export.pkg.version.swagger-codegen}",
+                            dart2.*;version="${export.pkg.version.swagger-codegen}",
                             dart2.auth;version="${export.pkg.version.swagger-codegen}",
                             elixir;version="${export.pkg.version.swagger-codegen}",
                             elm;version="${export.pkg.version.swagger-codegen}",
@@ -187,6 +192,7 @@
                             swift;version="${export.pkg.version.swagger-codegen}",
                             swift3;version="${export.pkg.version.swagger-codegen}",
                             swift4;version="${export.pkg.version.swagger-codegen}",
+                            swift5.*;version="${export.pkg.version.swagger-codegen}",
                             typescript-angular;version="${export.pkg.version.swagger-codegen}",
                             typescript-angularjs;version="${export.pkg.version.swagger-codegen}",
                             typescript-aurelia;version="${export.pkg.version.swagger-codegen}",
@@ -212,7 +218,7 @@
                         </Private-Package>
                         <Include-Resource>
                             {maven-resources},
-                            @openapi-generator-4.3.1.jar!/META-INF/services/*
+                            @openapi-generator-5.3.1.jar!/META-INF/services/*
                         </Include-Resource>
                         <_exportcontents>
                             com.github.jknack.handlebars,
@@ -232,6 +238,7 @@
                         <Embed-Dependency>
                             slf4j-ext;scope=compile|runtime;inline=false,
                             commons-io;scope=compile|runtime;inline=false,
+                            commonmark;scope=compile|runtime;inline=false
                         </Embed-Dependency>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
@@ -242,13 +249,13 @@
 
     <properties>
         <export.pkg.version.swagger-codegen>4.3.1.wso2v5</export.pkg.version.swagger-codegen>
-        <import.pkg.version.swagger-codegen>4.3.1</import.pkg.version.swagger-codegen>
+        <import.pkg.version.swagger-codegen>5.3.1</import.pkg.version.swagger-codegen>
         <jmustache-version>1.14</jmustache-version>
         <handlebars.java-version>4.1.2</handlebars.java-version>
-        <slf4j.api.version>1.7.12</slf4j.api.version>
+        <slf4j.api.version>1.7.32</slf4j.api.version>
         <commons-io-version>2.4</commons-io-version>
         <jackson.version.range>[2.7.0,3.0.0)</jackson.version.range>
-        <google.version.range>[27.0.0,33.0.0)</google.version.range>
+        <google.version.range>[31.0.0,33.0.0)</google.version.range>
         <slf4j.version.range>[1.7.0,1.8.0)</slf4j.version.range>
         <import.openapitools.parser.version.range>[2.0, 3.0)</import.openapitools.parser.version.range>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Purpose

- Fixed issue in version alignment issue with previously released 4.3.1.wso2v4 version.
- Related to https://github.com/wso2-enterprise/wso2-apim-internal/issues/3535

## Approach
- Add version ranges from 4.3.1.wso2v4.