### PR TITLE
Fix commons-io related dependencies of `4.3.1.wso2v5` to match `4.3.1.wso2v4`

### DIFF
--- a/openapi-generator/4.3.1.wso2v5/pom.xml
+++ b/openapi-generator/4.3.1.wso2v5/pom.xml
@@ -64,6 +64,7 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons-io-version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.commonmark</groupId>
@@ -229,7 +230,6 @@
                             com.google.common.collect,
                             com.google.common.io,
                             com.mifmif.common.regex,
-                            org.apache.commons.io,
                             org.commonmark.node,
                             org.commonmark.parser,
                             org.commonmark.renderer.html,
@@ -237,7 +237,6 @@
                         </_exportcontents>
                         <Embed-Dependency>
                             slf4j-ext;scope=compile|runtime;inline=false,
-                            commons-io;scope=compile|runtime;inline=false,
                             commonmark;scope=compile|runtime;inline=false
                         </Embed-Dependency>
                         <DynamicImport-Package>*</DynamicImport-Package>
@@ -253,7 +252,7 @@
         <jmustache-version>1.14</jmustache-version>
         <handlebars.java-version>4.1.2</handlebars.java-version>
         <slf4j.api.version>1.7.32</slf4j.api.version>
-        <commons-io-version>2.4</commons-io-version>
+        <commons-io-version>2.11.0</commons-io-version>
         <jackson.version.range>[2.7.0,3.0.0)</jackson.version.range>
         <google.version.range>[31.0.0,33.0.0)</google.version.range>
         <slf4j.version.range>[1.7.0,1.8.0)</slf4j.version.range>


### PR DESCRIPTION
## Purpose
> $Subject. Fixes https://github.com/wso2/api-manager/issues/2165

Overall, only the `<google.version.range>[31.0.0,33.0.0)</google.version.range>` is now different, when compared with `4.3.1.wso2v4`. 

Below will be the resultant diff between the `pom.xml` files `4.3.1.wso2v4` and the `4.3.1.wso2v5`, with this change going to `4.3.1.wso2v5`.

```diff
...		
    <modelVersion>4.0.0</modelVersion>	
    <groupId>org.wso2.orbit.org.openapitools</groupId>	
    <artifactId>openapi-generator</artifactId>
-   <version>4.3.1.wso2v4</version>
+   <version>4.3.1.wso2v5</version>

...

    <properties>
-        <export.pkg.version.swagger-codegen>4.3.1.wso2v4</export.pkg.version.swagger-codegen>
+        <export.pkg.version.swagger-codegen>4.3.1.wso2v5</export.pkg.version.swagger-codegen>
...
-         <google.version.range>[31.0.0,32.0.0)</google.version.range>
+         <google.version.range>[31.0.0,33.0.0)</google.version.range>
```

