### PR TITLE
jars for android client attestation

### DIFF
--- a/google-api-client/2.2.0.wso2v1/pom.xml
+++ b/google-api-client/2.2.0.wso2v1/pom.xml
@@ -1,20 +1,21 @@
 <!--
- ~ Copyright (c) 2023, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
- ~
- ~ WSO2 LLC licenses this file to you under the Apache License,
- ~ Version 2.0 (the "License"); you may not use this file except
- ~ in compliance with the License.
- ~ You may obtain a copy of the License at
- ~
- ~    http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~ Unless required by applicable law or agreed to in writing,
- ~ software distributed under the License is distributed on an
- ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- ~ KIND, either express or implied.  See the License for the
- ~ specific language governing permissions and limitations
- ~ under the License.
- -->
+  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/google-api-client/2.2.0.wso2v1/pom.xml
+++ b/google-api-client/2.2.0.wso2v1/pom.xml
@@ -1,0 +1,95 @@
+<!--
+ ~ Copyright (c) 2023, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+ ~
+ ~ WSO2 LLC licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.google.api-client</groupId>
+    <artifactId>google-api-client</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Google API Client</name>
+    <version>2.2.0.wso2v1</version>
+    <description>
+        This bundle will represent google-api-client 2.2.0
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>${google-api-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.google.api.client.googleapis.*;version="${google-api-client.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !com.google.api.client.googleapis.*,
+                            com.google.api.client.auth.oauth2;version="${google-oauth-client.orbit.imp.pkg.version}",
+                            com.google.api.client.auth.openidconnect;version="${google-oauth-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.apache.v2;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.javanet;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.json;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json.webtoken;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json.gson;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util.store;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.common.base;version="${google.guava.orbit.imp.pkg.version}",
+                            com.google.common.collect;version="${google.guava.orbit.imp.pkg.version}"
+                            com.google.common.io;version="${google.guava.orbit.imp.pkg.version}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <google-api-client.version>2.2.0</google-api-client.version>
+        <google-oauth-client.orbit.imp.pkg.version>[1.34.1,1.35.0)</google-oauth-client.orbit.imp.pkg.version>
+        <google-http-client.orbit.imp.pkg.version>[1.41.2,1.44.0)</google-http-client.orbit.imp.pkg.version>
+        <google.guava.orbit.imp.pkg.version>[31.0,32)</google.guava.orbit.imp.pkg.version>
+    </properties>
+</project>

--- a/google-api-services-play-integrity/2.0.0.wso2v1/pom.xml
+++ b/google-api-services-play-integrity/2.0.0.wso2v1/pom.xml
@@ -1,20 +1,21 @@
 <!--
- ~ Copyright (c) 2023, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
- ~
- ~ WSO2 LLC licenses this file to you under the Apache License,
- ~ Version 2.0 (the "License"); you may not use this file except
- ~ in compliance with the License.
- ~ You may obtain a copy of the License at
- ~
- ~    http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~ Unless required by applicable law or agreed to in writing,
- ~ software distributed under the License is distributed on an
- ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- ~ KIND, either express or implied.  See the License for the
- ~ specific language governing permissions and limitations
- ~ under the License.
- -->
+  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/google-api-services-play-integrity/2.0.0.wso2v1/pom.xml
+++ b/google-api-services-play-integrity/2.0.0.wso2v1/pom.xml
@@ -1,0 +1,90 @@
+<!--
+ ~ Copyright (c) 2023, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+ ~
+ ~ WSO2 LLC licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.google.api-services-playintegrity</groupId>
+    <artifactId>google-api-services-playintegrity</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Google Play Integrity API</name>
+    <version>2.0.0.wso2v1</version>
+    <description>
+        This bundle will represent Google Play Integrity API v1-rev20231018-2.0.0
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-playintegrity</artifactId>
+            <version>${google-api-services-play-integrity.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.google.api.services.playintegrity.*;version="${google-api-services-play-integrity-export.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !com.google.api.services.playintegrity.*,
+                            com.google.api.client.googleapis.*;version="${google-api-client.version}",
+                            com.google.api.client.http;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.apache.v2;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.javanet;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.json;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json.webtoken;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json.gson;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util.store;version="${google-http-client.orbit.imp.pkg.version}",                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <google-api-services-play-integrity-export.version>2.0.0.wso2v1</google-api-services-play-integrity-export.version>
+        <google-api-services-play-integrity.version>v1-rev20231018-2.0.0</google-api-services-play-integrity.version>
+        <google-http-client.orbit.imp.pkg.version>[1.41.2,1.44.0)</google-http-client.orbit.imp.pkg.version>
+        <google-api-client.version>2.2.0</google-api-client.version>
+    </properties>
+</project>

--- a/google-auth-library-oauth2-http/1.20.0.wso2v1/pom.xml
+++ b/google-auth-library-oauth2-http/1.20.0.wso2v1/pom.xml
@@ -71,8 +71,6 @@
                         </Private-Package>
                         <Import-Package>
                             !com.google.auth.*,
-<!--                            com.google.api.client.auth.oauth2;version="${google-oauth-client.orbit.imp.pkg.version}",-->
-<!--                            com.google.api.client.auth.openidconnect;version="${google-oauth-client.orbit.imp.pkg.version}",-->
                             com.google.api.client.http;version="${google-http-client.orbit.imp.pkg.version}",
                             com.google.api.client.http.apache.v2;version="${google-http-client.orbit.imp.pkg.version}",
                             com.google.api.client.http.javanet;version="${google-http-client.orbit.imp.pkg.version}",

--- a/google-auth-library-oauth2-http/1.20.0.wso2v1/pom.xml
+++ b/google-auth-library-oauth2-http/1.20.0.wso2v1/pom.xml
@@ -1,20 +1,21 @@
 <!--
- ~ Copyright (c) 2023, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
- ~
- ~ WSO2 LLC licenses this file to you under the Apache License,
- ~ Version 2.0 (the "License"); you may not use this file except
- ~ in compliance with the License.
- ~ You may obtain a copy of the License at
- ~
- ~    http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~ Unless required by applicable law or agreed to in writing,
- ~ software distributed under the License is distributed on an
- ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- ~ KIND, either express or implied.  See the License for the
- ~ specific language governing permissions and limitations
- ~ under the License.
- -->
+  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/google-auth-library-oauth2-http/1.20.0.wso2v1/pom.xml
+++ b/google-auth-library-oauth2-http/1.20.0.wso2v1/pom.xml
@@ -1,0 +1,101 @@
+<!--
+ ~ Copyright (c) 2023, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+ ~
+ ~ WSO2 LLC licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.google.auth-library-oauth2-http</groupId>
+    <artifactId>google-auth-library-oauth2-http</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Google Auth Library for Java </name>
+    <version>1.20.0.wso2v1</version>
+    <description>
+        This bundle will represent google-auth-library-oauth2-http 1.20.0
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-credentials</artifactId>
+            <version>${google-auth-library.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+            <version>${google-auth-library.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.google.auth.*;version="${google-auth-library.version}",
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !com.google.auth.*,
+<!--                            com.google.api.client.auth.oauth2;version="${google-oauth-client.orbit.imp.pkg.version}",-->
+<!--                            com.google.api.client.auth.openidconnect;version="${google-oauth-client.orbit.imp.pkg.version}",-->
+                            com.google.api.client.http;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.apache.v2;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.javanet;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.http.json;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json.webtoken;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.json.gson;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.api.client.util.store;version="${google-http-client.orbit.imp.pkg.version}",
+                            com.google.common.base;version="${google.guava.orbit.imp.pkg.version}",
+                            com.google.common.collect;version="${google.guava.orbit.imp.pkg.version}"
+                            com.google.common.io;version="${google.guava.orbit.imp.pkg.version}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <google-auth-library.version>1.20.0</google-auth-library.version>
+        <google-oauth-client.orbit.imp.pkg.version>[1.34.1,1.35.0)</google-oauth-client.orbit.imp.pkg.version>
+        <google-http-client.orbit.imp.pkg.version>[1.41.2,1.44.0)</google-http-client.orbit.imp.pkg.version>
+        <google.guava.orbit.imp.pkg.version>[31.0,32)</google.guava.orbit.imp.pkg.version>
+    </properties>
+</project>

--- a/google-http-client/1.43.3.wso2v1/pom.xml
+++ b/google-http-client/1.43.3.wso2v1/pom.xml
@@ -1,0 +1,157 @@
+<!--
+ ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.google.http-client</groupId>
+    <artifactId>google-http-client</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Google http Client</name>
+    <version>1.43.3.wso2v1</version>
+    <description>
+        This bundle will represent google-http-client 1.43.3
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>${google-http-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client-jackson2</artifactId>
+            <version>${google-http-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client-gson</artifactId>
+            <version>${google-http-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client-apache-v2</artifactId>
+            <version>${google-http-client.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.google.api.client.http.*;version="${google-http-client.version}",
+                            com.google.api.client.json.*;version="${google-http-client.version}",
+                            com.google.api.client.json.gson.*;version="${google-http-client.version}",
+                            com.google.api.client.repackaged.*;version="${google-http-client.version}",
+                            com.google.api.client.util.*;version="${google-http-client.version}",
+                            com.google.api.client.http.apache.v2.*;version="${google-http-client.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !com.google.api.client.http.*,
+                            !com.google.api.client.json.*,
+                            !com.google.api.client.json.gson.*,
+                            !com.google.api.client.repackaged.*,
+                            !com.google.api.client.util.*,
+                            !com.google.api.client.http.apache.v2.*,
+                            com.fasterxml.jackson.core;version="${jackson-core.orbit.imp.pkg.version}",
+<!--                            com.google.api.client.auth.oauth2;version="${google-oauth-client.orbit.imp.pkg.version}",-->
+                            com.google.common.base;version="${google-guava.imp.pkg.version}",
+                            com.google.common.collect;version="${google-guava.imp.pkg.version}",
+                            com.google.common.io;version="${google-guava.imp.pkg.version}",
+                            com.google.common.util.concurrent;version="${google-guava.imp.pkg.version}",
+                            org.apache.http;version="${httpcore.orbit.imp.pkg.version}",
+                            org.apache.http.entity;version="${httpcore.orbit.imp.pkg.version}",
+                            org.apache.http.params;version="${httpcore.orbit.imp.pkg.version}",
+                            org.apache.http.client;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.client.methods;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn.params;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn.routing;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn.scheme;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.conn.ssl;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.impl.client;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.impl.conn;version="${httpclient.orbit.imp.pkg.version}",
+                            org.apache.http.impl.conn.tsccm;version="${httpclient.orbit.imp.pkg.version}",
+                            io.opencensus.common;version="${opencensus.orbit.imp.pkg.version}",
+                            io.opencensus.contrib.http.util;version="${opencensus.orbit.imp.pkg.version}",
+                            io.opencensus.trace;version="${opencensus.orbit.imp.pkg.version}",
+                            io.opencensus.trace.export;version="${opencensus.orbit.imp.pkg.version}",
+                            io.opencensus.trace.propagation;version="${opencensus.orbit.imp.pkg.version}",
+                            javax.annotation,
+                            javax.net.ssl
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <google-http-client.version>1.43.3</google-http-client.version>
+        <jackson-core.orbit.imp.pkg.version>[2.6.0,3.0.0)</jackson-core.orbit.imp.pkg.version>
+        <google-oauth-client.orbit.imp.pkg.version>[1.33.1,1.34.0)</google-oauth-client.orbit.imp.pkg.version>
+        <google-guava.imp.pkg.version>[31.0,32)</google-guava.imp.pkg.version>
+        <httpcore.orbit.imp.pkg.version>[4.4.15,4.5.0)</httpcore.orbit.imp.pkg.version>
+        <httpclient.orbit.imp.pkg.version>[4.5.13,4.6.0)</httpclient.orbit.imp.pkg.version>
+        <opencensus.orbit.imp.pkg.version>[0.30.0,1.0.0)</opencensus.orbit.imp.pkg.version>
+    </properties>
+
+</project>

--- a/google-http-client/1.43.3.wso2v1/pom.xml
+++ b/google-http-client/1.43.3.wso2v1/pom.xml
@@ -1,7 +1,7 @@
 <!--
- ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~ Copyright (c) 2023, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
  ~
- ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ WSO2 LLC licenses this file to you under the Apache License,
  ~ Version 2.0 (the "License"); you may not use this file except
  ~ in compliance with the License.
  ~ You may obtain a copy of the License at
@@ -112,7 +112,6 @@
                             !com.google.api.client.util.*,
                             !com.google.api.client.http.apache.v2.*,
                             com.fasterxml.jackson.core;version="${jackson-core.orbit.imp.pkg.version}",
-<!--                            com.google.api.client.auth.oauth2;version="${google-oauth-client.orbit.imp.pkg.version}",-->
                             com.google.common.base;version="${google-guava.imp.pkg.version}",
                             com.google.common.collect;version="${google-guava.imp.pkg.version}",
                             com.google.common.io;version="${google-guava.imp.pkg.version}",

--- a/google-http-client/1.43.3.wso2v1/pom.xml
+++ b/google-http-client/1.43.3.wso2v1/pom.xml
@@ -1,20 +1,21 @@
 <!--
- ~ Copyright (c) 2023, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
- ~
- ~ WSO2 LLC licenses this file to you under the Apache License,
- ~ Version 2.0 (the "License"); you may not use this file except
- ~ in compliance with the License.
- ~ You may obtain a copy of the License at
- ~
- ~    http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~ Unless required by applicable law or agreed to in writing,
- ~ software distributed under the License is distributed on an
- ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- ~ KIND, either express or implied.  See the License for the
- ~ specific language governing permissions and limitations
- ~ under the License.
- -->
+  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/grpc-contex/1.59.0.wso2v1/pom.xml
+++ b/grpc-contex/1.59.0.wso2v1/pom.xml
@@ -21,13 +21,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.wso2.orbit.io.opencensus</groupId>
-    <artifactId>opencensus</artifactId>
-    <version>0.31.1.wso2v1</version>
+    <groupId>org.wso2.orbit.io.grpc</groupId>
+    <artifactId>grpc-context</artifactId>
+    <version>1.59.0.wso2v1</version>
     <packaging>bundle</packaging>
-    <name>WSO2 Carbon Orbit - OpenCensus</name>
+    <name>WSO2 Carbon Orbit - GRPC Context</name>
     <description>
-        This bundle will represent OpenCensus 0.31.1
+        This bundle will represent GRPC Context 1.59.0
     </description>
     <url>http://wso2.org</url>
 
@@ -59,14 +59,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.opencensus</groupId>
-            <artifactId>opencensus-api</artifactId>
-            <version>${opencensus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opencensus</groupId>
-            <artifactId>opencensus-contrib-http-util</artifactId>
-            <version>${opencensus.version}</version>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-context</artifactId>
+            <version>${grpc-context.version}</version>
         </dependency>
     </dependencies>
 
@@ -82,18 +77,12 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
-                            io.opencensus.*; version=${opencensus.version},
-                            io.opencensus.contrib.http.util.*; version=${opencensus.version},
+                            io.grpc.*; version=${grpc-context.version},
                         </Export-Package>
                         <Private-Package>
                         </Private-Package>
                         <Import-Package>
-                            !io.opencensus.*,
-                            com.google.common.base;version="${google.guava.orbit.imp.pkg.version}",
-                            com.google.common.annotations;version="${google.guava.orbit.imp.pkg.version}"
-                            com.google.common.collect;version="${google.guava.orbit.imp.pkg.version}"
-                            com.google.common.primitives;version="${google.guava.orbit.imp.pkg.version}",
-                            io.grpc.*;version="${io.grpc.orbit.imp.pkg.version}",
+                            !io.grpc.*
                         </Import-Package>
                     </instructions>
                 </configuration>
@@ -102,8 +91,6 @@
     </build>
 
     <properties>
-        <opencensus.version>0.31.1</opencensus.version>
-        <google.guava.orbit.imp.pkg.version>[31.0,32)</google.guava.orbit.imp.pkg.version>
-        <io.grpc.orbit.imp.pkg.version>[1.59.0,2)</io.grpc.orbit.imp.pkg.version>
+        <grpc-context.version>1.59.0</grpc-context.version>
     </properties>
 </project>

--- a/opencensus/0.31.1.wso2v1/pom.xml
+++ b/opencensus/0.31.1.wso2v1/pom.xml
@@ -1,0 +1,108 @@
+<!--
+ ~ Copyright (c) 2023 WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+ ~
+ ~ WSO2 LLC licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.io.opencensus</groupId>
+    <artifactId>opencensus</artifactId>
+    <version>0.31.1.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - OpenCensus</name>
+    <description>
+        This bundle will represent OpenCensus 0.31.1
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-api</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-contrib-http-util</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.opencensus.*; version=${opencensus.version},
+                            io.opencensus.contrib.http.util.*; version=${opencensus.version},
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !io.opencensus.*,
+                            com.google.common.base;version="${google.guava.orbit.imp.pkg.version}",
+                            com.google.common.annotations;version="${google.guava.orbit.imp.pkg.version}"
+                            com.google.common.collect;version="${google.guava.orbit.imp.pkg.version}"
+                            com.google.common.primitives;version="${google.guava.orbit.imp.pkg.version}",
+                            io.grpc;version="${io.grpc.orbit.imp.pkg.version}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <opencensus.version>0.31.1</opencensus.version>
+        <google.guava.orbit.imp.pkg.version>[31.0,32)</google.guava.orbit.imp.pkg.version>
+        <io.grpc.orbit.imp.pkg.version>[1.27.2,2)</io.grpc.orbit.imp.pkg.version>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose
Issue: https://github.com/wso2/product-is/issues/16836

Add jars to support Android PlayIntegrity Client Attestation Service.
google-api-services-playintegrity jar version changed to 2.0.0 cause the original version is "v1-rev20231018-2.0.0" and its not compatible for eclispe plugin installment by causing numeric exveption

- [x] Secrity checks for newly added jars - Mail: Request to approve using Google Play and Auth Libraries - Vulnerability Report

- [x] Tested the bundle usage with WSO2 IS 7.0.0 Alpha 2
