### PR TITLE
JSON path 2.9.0

### DIFF
--- a/jsonpath/2.9.0.wso2v1/pom.xml
+++ b/jsonpath/2.9.0.wso2v1/pom.xml
@@ -68,10 +68,6 @@
                             org.slf4j.*;version="[2.0.0,3)",
                             *;resolution:=optional
                         </Import-Package>
-                        <Embed-Dependency>
-                            json-smart;scope=compile|runtime;inline=false,
-                            asm;scope=compile|runtime;inline=false,
-                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/jsonpath/2.9.0.wso2v1/pom.xml
+++ b/jsonpath/2.9.0.wso2v1/pom.xml
@@ -59,7 +59,7 @@
                             !com.jayway.jsonpath.internal.*; version="${jayway.jsonpath.version}",
                         </Export-Package>
                         <Import-Package>
-                            org.slf4j.*;version="[1.6.1,3)",
+                            org.slf4j.*;version="[1.7.36,3)",
                             *;resolution:=optional
                         </Import-Package>
                         <Private-Package>

--- a/jsonpath/2.9.0.wso2v1/pom.xml
+++ b/jsonpath/2.9.0.wso2v1/pom.xml
@@ -35,11 +35,6 @@
             <version>${jayway.jsonpath.version}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>${net.mindev.jsonsmart.version}</version>
-        </dependency>
     </dependencies>
     <distributionManagement>
         <repository>
@@ -61,13 +56,14 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
                             com.jayway.jsonpath.*; version="${jayway.jsonpath.version}",
+                            !com.jayway.jsonpath.internal.*; version="${jayway.jsonpath.version}",
                         </Export-Package>
                         <Import-Package>
-                            !com.jayway.jsonpath.*,
-                            net.minidev.json.*; version="[2.5.0,3)",
                             org.slf4j.*;version="[1.6.1,3)",
                             *;resolution:=optional
                         </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
                     </instructions>
                 </configuration>
             </plugin>
@@ -75,6 +71,5 @@
     </build>
     <properties>
         <jayway.jsonpath.version>2.9.0</jayway.jsonpath.version>
-        <net.mindev.jsonsmart.version>2.5.0</net.mindev.jsonsmart.version>
     </properties>
 </project>

--- a/jsonpath/2.9.0.wso2v1/pom.xml
+++ b/jsonpath/2.9.0.wso2v1/pom.xml
@@ -65,7 +65,7 @@
                         <Import-Package>
                             !com.jayway.jsonpath.*,
                             net.minidev.json.*; version="[2.5.0,3)",
-                            org.slf4j.*;version="[2.0.0,3)",
+                            org.slf4j.*;version="[1.6.1,3)",
                             *;resolution:=optional
                         </Import-Package>
                     </instructions>

--- a/jsonpath/2.9.0.wso2v1/pom.xml
+++ b/jsonpath/2.9.0.wso2v1/pom.xml
@@ -1,0 +1,84 @@
+<!--
+ ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.jayway.jsonpath</groupId>
+    <artifactId>json-path</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - JSON path Library</name>
+    <version>2.9.0.wso2v1</version>
+    <description>
+        This bundle will export packages from json path library
+    </description>
+    <url>http://wso2.org</url>
+    <dependencies>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${jayway.jsonpath.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>${net.mindev.jsonsmart.version}</version>
+        </dependency>
+    </dependencies>
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.jayway.jsonpath.*; version="${jayway.jsonpath.version}",
+                        </Export-Package>
+                        <Import-Package>
+                            !com.jayway.jsonpath.*,
+                            net.minidev.json.*; version="[2.5.0,3)",
+                            org.slf4j.*;version="[2.0.0,3)",
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>
+                            json-smart;scope=compile|runtime;inline=false,
+                            asm;scope=compile|runtime;inline=false,
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <jayway.jsonpath.version>2.9.0</jayway.jsonpath.version>
+        <net.mindev.jsonsmart.version>2.5.0</net.mindev.jsonsmart.version>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose
Upgrade the jsonpath to latest level (2.9.0) with json-smart 2.5.0

```diff
...	
-           <dependency>
-                 <groupId>net.minidev</groupId>
-                 <artifactId>json-smart</artifactId>
-                 <version>${net.mindev.jsonsmart.version}</version>
-            </dependency>	
-            <dependency>
-                  <groupId>net.minidev</groupId>
-                  <artifactId>asm</artifactId>
-                  <version>${net.mindev.asm.version}</version>
-             </dependency>
...
-            <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
-            <Bundle-Name>${pom.artifactId}</Bundle-Name>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Name>${project.artifactId}</Bundle-Name>
...
-             net.minidev.json.*; version="[2.1.0,3)",
-             org.slf4j.*;version="[1.6.1,2)",
+            org.slf4j.*;version="[1.6.1,3)",
...
-            <jayway.jsonpath.version>2.6.0</jayway.jsonpath.version>
+            <jayway.jsonpath.version>2.9.0</jayway.jsonpath.version>
-            <net.mindev.jsonsmart.version>2.4.11</net.mindev.jsonsmart.version>
-            <net.mindev.asm.version>1.0.2</net.mindev.asm.version>
-            <commons.lang.version>2.6</commons.lang.version>


...
```