### PR TITLE
Add H2 Engine Version `2.2.224.wso2v2`

### DIFF
--- a/h2-engine/2.2.224.wso2v2/pom.xml
+++ b/h2-engine/2.2.224.wso2v2/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <groupId>org.wso2.orbit.com.h2database</groupId>
+    <artifactId>h2-engine</artifactId>
+    <version>2.2.224.wso2v1</version>
+    <packaging>bundle</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <name>WSO2 Carbon Orbit - H2 OSGi Database Service</name>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+            <version>3.9.1.v20130814-1242</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <h2.engine.orbit.version>2.2.224.wso2v1</h2.engine.orbit.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Private-Package>org.h2.*</Private-Package>
+                        <Export-Package>
+                            org.wso2.carbon.h2.osgi.*;version="${h2.engine.orbit.version}",
+                        </Export-Package>
+                        <_exportcontents>org.h2.*;version="${h2.engine.orbit.version}"</_exportcontents>
+                        <Bundle-Activator>org.wso2.carbon.h2.osgi.H2DatabaseServiceActivator</Bundle-Activator>
+                        <Import-Package>
+                            org.apache.lucene.analysis;version="[3.6.2,4.0.0)";resolution:=optional,
+                            org.apache.lucene.analysis.standard;version="[3.6.2,4.0.0)";resolution:=optional,
+                            org.apache.lucene.document;version="[3.6.2,4.0.0)";resolution:=optional,
+                            org.apache.lucene.index;version="[3.6.2,4.0.0)";resolution:=optional,
+                            org.apache.lucene.queryParser;version="[3.6.2,4.0.0)";resolution:=optional,
+                            org.apache.lucene.search;version="[3.6.2,4.0.0)";resolution:=optional,
+                            org.apache.lucene.store;version="[3.6.2,4.0.0)";resolution:=optional,
+                            org.apache.lucene.util;version="[3.6.2,4.0.0)";resolution:=optional,
+                            com.vividsolutions.jts.geom;version="1.14.0";resolution:=optional,
+                            com.vividsolutions.jts.io;version="1.14.0";resolution:=optional,
+                            org.h2;version="[${project.version},2.3.0)",
+                            org.h2.api;version="[${project.version},2.3.0)",
+                            org.h2.fulltext;version="[${project.version},2.3.0)",
+                            org.h2.jdbcx;version="[${project.version},2.3.0)",
+                            org.h2.util;version="[${project.version},2.3.0)",
+                            org.h2.value;version="[${project.version},2.3.0)",
+                            org.osgi.framework,
+                            org.osgi.service.jdbc;resolution:=optional,
+                            org.slf4j;version="[1.6.0,1.7.0)";resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>
+                            h2;scope=compile|runtime;inline=false;
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/h2-engine/2.2.224.wso2v2/pom.xml
+++ b/h2-engine/2.2.224.wso2v2/pom.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <groupId>org.wso2.orbit.com.h2database</groupId>
     <artifactId>h2-engine</artifactId>
-    <version>2.2.224.wso2v1</version>
+    <version>2.2.224.wso2v2</version>
     <packaging>bundle</packaging>
     <modelVersion>4.0.0</modelVersion>
     <name>WSO2 Carbon Orbit - H2 OSGi Database Service</name>
@@ -56,7 +56,7 @@
     </dependencies>
 
     <properties>
-        <h2.engine.orbit.version>2.2.224.wso2v1</h2.engine.orbit.version>
+        <h2.engine.orbit.version>2.2.224.wso2v2</h2.engine.orbit.version>
     </properties>
 
     <repositories>

--- a/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/H2DatabaseServiceActivator.java
+++ b/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/H2DatabaseServiceActivator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.h2.osgi;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.wso2.carbon.h2.osgi.database.H2DatabaseManager;
+
+/**
+ * This class is used to activate and deactivate the H2 database service.
+ */
+public class H2DatabaseServiceActivator implements BundleActivator {
+
+    /**
+     * This method is used to start the H2 database service.
+     *
+     * @param arg0 BundleContext.
+     */
+    public void start(BundleContext arg0) {
+
+        H2DatabaseManager.getInstance().initialize();
+    }
+
+    /**
+     * This method is used to stop the H2 database service.
+     *
+     * @param arg0 BundleContext.
+     */
+    public void stop(BundleContext arg0) {
+
+        H2DatabaseManager.getInstance().terminate();
+    }
+}

--- a/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/console/ConsoleService.java
+++ b/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/console/ConsoleService.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.h2.osgi.console;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.h2.server.ShutdownHandler;
+import org.h2.tools.Console;
+import org.h2.tools.Server;
+import org.h2.util.Tool;
+
+import java.sql.SQLException;
+
+/**
+ * Holds functions related to the H2 console service.
+ */
+public class ConsoleService extends Tool implements ShutdownHandler {
+
+    private static final Log log = LogFactory.getLog(ConsoleService.class);
+
+    private Server web, tcp, pg;
+    private boolean isWindows;
+
+    /**
+     * When running without options, -tcp, -web, -browser and -pg are started.
+     * <br />
+     * Options are case sensitive. Supported options are:
+     * <table>
+     * <tr><td>[-help] or [-?]</td>
+     * <td>Print the list of options</td></tr>
+     * <tr><td>[-web]</td>
+     * <td>Start the web server with the H2 Console</td></tr>
+     * <tr><td>[-browser]</td>
+     * <td>Start a browser and open a page to connect to the web server</td></tr>
+     * <tr><td>[-tcp]</td>
+     * <td>Start the TCP server</td></tr>
+     * <tr><td>[-pg]</td>
+     * <td>Start the PG server</td></tr>
+     * </table>
+     * For each Server, additional options are available;
+     * for details, see the Server tool.<br />
+     * If a service can not be started, the program
+     * terminates with an exit code of 1.
+     *
+     * @param args the command line arguments
+     * @h2.resource
+     */
+    public static void main(String[] args) throws SQLException {
+
+        new Console().runTool(args);
+    }
+
+    /**
+     * This tool starts the H2 Console (web-) server, as well as the TCP and PG
+     * server. For JDK 1.6, a system tray icon is created, for platforms that
+     * support it. Otherwise, a small window opens.
+     *
+     * @param args the command line arguments
+     */
+    public void runTool(String[] args) throws SQLException {
+
+        isWindows = System.getProperty("os.name").startsWith("Windows");
+        boolean tcpStart = false, pgStart = false, webStart = false;
+        boolean browserStart = false;
+
+        for (int i = 0; args != null && i < args.length; i++) {
+            String arg = args[i];
+            if (arg == null) {
+                continue;
+            } else if ("-?".equals(arg) || "-help".equals(arg)) {
+                showUsage();
+                return;
+            } else if ("-web".equals(arg)) {
+                webStart = true;
+            } else if ("-browser".equals(arg)) {
+                webStart = true;
+                browserStart = true;
+            } else if ("-tcp".equals(arg)) {
+                tcpStart = true;
+            } else if ("-pg".equals(arg)) {
+                pgStart = true;
+            }
+        }
+        SQLException startException = null;
+        boolean webRunning = false;
+        if (webStart) {
+            try {
+                web = Server.createWebServer(args);
+                web.setShutdownHandler(this);
+                web.start();
+                log.info("Starting H2 Web server...");
+                webRunning = true;
+            } catch (SQLException e) {
+                printProblem(e, web);
+                startException = e;
+            }
+        }
+        if (tcpStart) {
+            try {
+                tcp = Server.createTcpServer(args);
+                tcp.start();
+                log.info("Starting H2 TCP server...");
+            } catch (SQLException e) {
+                printProblem(e, tcp);
+                if (startException == null) {
+                    startException = e;
+                }
+            }
+        }
+        if (pgStart) {
+            try {
+                pg = Server.createPgServer(args);
+                pg.start();
+                log.info("Starting H2 PG server...");
+            } catch (SQLException e) {
+                printProblem(e, pg);
+                if (startException == null) {
+                    startException = e;
+                }
+            }
+        }
+
+        // start browser anyway (even if the server is already running)
+        // because some people don't look at the output,
+        // but are wondering why nothing happens
+        if (browserStart) {
+            try {
+                Server.openBrowser(web.getURL());
+            } catch (Exception e) {
+                throw new RuntimeException("Error while opening the Brwoser ", e);
+            }
+        }
+        if (startException != null) {
+            throw startException;
+        }
+    }
+
+    private void printProblem(SQLException e, Server server) {
+
+        log.error("Error when starting H2 servers", e);
+        if (server != null) {
+            out.println(server.getStatus());
+            out.println("Root cause: " + e.getMessage());
+        }
+    }
+
+    /**
+     * INTERNAL
+     */
+    public void shutdown() {
+
+        stopAll();
+    }
+
+    /**
+     * Stop all servers that were started using the console.
+     */
+    void stopAll() {
+
+        if (web != null && web.isRunning(false)) {
+            web.stop();
+            web = null;
+            log.info("Stopping H2 Web server...");
+        }
+        if (tcp != null && tcp.isRunning(false)) {
+            tcp.stop();
+            tcp = null;
+            log.info("Stopping H2 TCP server...");
+        }
+        if (pg != null && pg.isRunning(false)) {
+            pg.stop();
+            pg = null;
+            log.info("Stopping H2 PG server...");
+        }
+    }
+
+    public boolean isServerRunning() {
+
+        return ((web != null && web.isRunning(false)) || (tcp != null && tcp.isRunning(false)) ||
+                (pg != null && pg.isRunning(false)));
+    }
+}

--- a/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/console/H2DatabaseManager.java
+++ b/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/console/H2DatabaseManager.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.h2.osgi.console;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.h2.Driver;
+import org.h2.engine.Database;
+import org.h2.engine.Engine;
+import org.wso2.carbon.h2.osgi.utils.CarbonUtils;
+import org.wso2.carbon.h2.osgi.utils.H2Constants;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * H2 Database Manager.
+ */
+public class H2DatabaseManager {
+
+    private static H2DatabaseManager instance;
+    private static final Log log = LogFactory.getLog(H2DatabaseManager.class);
+
+    private ConsoleService console;
+
+    private H2DatabaseManager() {
+    }
+
+    public synchronized static H2DatabaseManager getInstance() {
+
+        if (instance == null)
+            instance = new H2DatabaseManager();
+        return instance;
+    }
+
+    public void initialize() throws SQLException {
+
+        Driver.load();
+        startH2Server();
+    }
+
+    public void terminate() {
+
+        stopH2Server();
+        closeAllOpenDatabases();
+    }
+
+    private void closeAllOpenDatabases() {
+
+        Field f[] = Engine.class.getDeclaredFields();
+
+        for (Field var : f) {
+            if ((var.getType() == HashMap.class) && (var.getName().equals(H2Constants.ENGINE_VAR_DATABASES))) {
+                var.setAccessible(true);
+                Object pass = new Object();
+                try {
+                    Object fieldValue = var.get(pass);
+                    if (fieldValue.getClass() == HashMap.class) {
+                        HashMap DATABASES = (HashMap) fieldValue;
+
+                        List<Database> openDatabases = new ArrayList<Database>();
+                        for (Iterator iterator = DATABASES.values().iterator(); iterator.hasNext(); ) {
+                            Database database = (Database) iterator.next();
+                            openDatabases.add(database);
+                        }
+
+                        for (Iterator iterator = openDatabases.iterator(); iterator.hasNext(); ) {
+                            Database database = (Database) iterator.next();
+                            Method declaredMethod = null;
+                            try {
+                                declaredMethod = database.getClass().getDeclaredMethod(H2Constants.ENGINE_METHOD_CLOSE,
+                                        new Class[]{boolean.class});
+                                if (declaredMethod != null) {
+                                    declaredMethod.setAccessible(true);
+                                    declaredMethod.invoke(database, new Object[]{true});
+                                } else {
+                                    log.error("Database close method not found in class " +
+                                            database.getClass().getName());
+                                }
+                            } catch (SecurityException e) {
+                                log.error("Error when closing H2 database", e);
+                            } catch (NoSuchMethodException e) {
+                                log.error("Error when closing H2 database", e);
+                            } catch (InvocationTargetException e) {
+                                log.error("Error when closing H2 database", e);
+                            }
+                        }
+                    }
+                } catch (IllegalArgumentException e) {
+                    log.error("Error when closing H2 database", e);
+                } catch (IllegalAccessException e) {
+                    log.error("Error when closing H2 database", e);
+                }
+            }
+        }
+
+    }
+
+    public void startH2Server() throws SQLException {
+
+        if (console == null) {
+            console = new ConsoleService();
+        } else if (console.isServerRunning())
+            stopH2Server();
+        console.runTool(getH2Parameters());
+    }
+
+    public void stopH2Server() {
+
+        if ((console != null) && (console.isServerRunning()))
+            console.shutdown();
+    }
+
+    private String[] getH2Parameters() {
+
+        List parameterList = new ArrayList();
+        Map parameters = CarbonUtils.getH2Parameters();
+        for (Iterator iterator = parameters.keySet().iterator(); iterator.hasNext(); ) {
+            String paraName = (String) iterator.next();
+            parameterList.add("-" + paraName);
+            if ((parameters.get(paraName) != null) && (!parameters.get(paraName).equals(""))) {
+                String value = parameters.get(paraName).toString();
+                parameterList.add(value);
+            }
+        }
+        return (String[]) parameterList.toArray(new String[]{});
+    }
+}

--- a/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/database/H2DatabaseManager.java
+++ b/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/database/H2DatabaseManager.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.h2.osgi.database;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.h2.Driver;
+import org.h2.engine.Database;
+import org.h2.engine.Engine;
+import org.wso2.carbon.h2.osgi.utils.H2Constants;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * H2 Database Manager.
+ */
+public class H2DatabaseManager {
+
+    private static final H2DatabaseManager instance = new H2DatabaseManager();
+    private static final Log log = LogFactory.getLog(H2DatabaseManager.class);
+
+    private H2DatabaseManager() {
+    }
+
+    /**
+     * Get the instance of the H2DatabaseManager.
+     *
+     * @return H2DatabaseManager instance.
+     */
+    public synchronized static H2DatabaseManager getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Initialize the H2DatabaseManager.
+     */
+    public void initialize() {
+
+        Driver.load();
+    }
+
+    /**
+     * Terminate the H2DatabaseManager.
+     */
+    public void terminate() {
+
+        closeAllOpenDatabases();
+    }
+
+    private void closeAllOpenDatabases() {
+
+        Field fields[] = Engine.class.getDeclaredFields();
+
+        for (Field var : fields) {
+            if ((var.getType() == HashMap.class) && (H2Constants.ENGINE_VAR_DATABASES.equals(var.getName()))) {
+                var.setAccessible(true);
+                Object pass = new Object();
+                try {
+                    Object fieldValue = var.get(pass);
+                    if (fieldValue instanceof HashMap) {
+                        Map<String, Database> databases = (HashMap<String, Database>) fieldValue;
+
+                        List<Database> openDatabases = new ArrayList<Database>();
+                        openDatabases.addAll(databases.values());
+
+                        for (Iterator iterator = openDatabases.iterator(); iterator.hasNext(); ) {
+                            Database database = (Database) iterator.next();
+                            Method declaredMethod = null;
+                            try {
+                                declaredMethod = database.getClass().getDeclaredMethod(H2Constants.ENGINE_METHOD_CLOSE,
+                                        new Class[]{boolean.class});
+                                if (declaredMethod != null) {
+                                    declaredMethod.setAccessible(true);
+                                    declaredMethod.invoke(database, new Object[]{true});
+                                } else {
+                                    log.error("Database close method not found in class " +
+                                            database.getClass().getName());
+                                }
+                            } catch (InvocationTargetException | NoSuchMethodException | SecurityException e) {
+                                log.error("Error when closing H2 database", e);
+                            }
+                        }
+                    }
+                } catch (IllegalAccessException | IllegalArgumentException e) {
+                    log.error("Error when closing H2 database", e);
+                }
+            }
+        }
+    }
+}

--- a/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/utils/CarbonConstants.java
+++ b/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/utils/CarbonConstants.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.h2.osgi.utils;
+
+/**
+ * Holds the carbon related constants.
+ */
+public class CarbonConstants {
+
+    public static final String CARBON_HOME = "carbon.home";
+    public static final String CARBON_HOME_ENV = "CARBON_HOME";
+    public static final String CARBON_HOME_PARAMETER = "${carbon.home}";
+    public static final String CARBON_XML_FILE = "carbon.xml";
+    public static final String CONF_FOLDER = "conf";
+    public static final String TAG_DB_CONFIGURATION = "H2DatabaseConfiguration";
+    public static final String TAG_PROPERTY = "property";
+    public static final String ATTRIBUTE_NAME = "name";
+}

--- a/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/utils/CarbonUtils.java
+++ b/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/utils/CarbonUtils.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.h2.osgi.utils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+/**
+ * Utility class for Carbon functions.
+ */
+public class CarbonUtils {
+
+    private static Log log = LogFactory.getLog(CarbonUtils.class);
+
+    public static String getCarbonXmlFilePath() {
+
+        String carbonXmlPath =
+                System.getProperty(CarbonConstants.CARBON_HOME) + File.separator + "repository" + File.separator +
+                        CarbonConstants.CONF_FOLDER + File.separator + CarbonConstants.CARBON_XML_FILE;
+        try {
+            new File(carbonXmlPath);
+            return carbonXmlPath;
+        } catch (Exception e) {
+            //the property is invalid does not exist keep using the default file path
+            log.error("Error while retrieving carbon XML file path from carbon context", e);
+        }
+        return null;
+    }
+
+    public static Map getH2Parameters() {
+
+        Map h2Properties = new HashMap();
+        H2Utils.resetToDefaultParameters(h2Properties);
+        String carbonXmlFile = getCarbonXmlFilePath();
+        try {
+            File file = new File(carbonXmlFile);
+            if (!file.exists()) {
+                return h2Properties;
+            }
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            Document doc = db.parse(file);
+            doc.getDocumentElement().normalize();
+            Element rootEle = doc.getDocumentElement();
+            NodeList childNodes2 = rootEle.getChildNodes();
+            Node dbConfigurationNode = null;
+            Map h2PropertiesConfigured = new HashMap();
+            for (int i = 0; i < childNodes2.getLength(); i++) {
+                Node propertyEle = (Node) childNodes2.item(i);
+                if (propertyEle.getNodeName().equals(CarbonConstants.TAG_DB_CONFIGURATION)) {
+                    dbConfigurationNode = propertyEle;
+                }
+            }
+            if (dbConfigurationNode == null)
+                return h2Properties;
+
+            NodeList childNodes = dbConfigurationNode.getChildNodes();
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node propertyEle = (Node) childNodes.item(i);
+                if (!propertyEle.getNodeName().equals(CarbonConstants.TAG_PROPERTY))
+                    continue;
+                NamedNodeMap propertyAttribs = propertyEle.getAttributes();
+                Node nameAttrib = propertyAttribs.getNamedItem(CarbonConstants.ATTRIBUTE_NAME);
+                String transport;
+                if (nameAttrib == null) {
+                    continue;
+                }
+                String paraName = nameAttrib.getNodeValue();
+                String value = propertyEle.getTextContent();
+                if (H2Constants.getParameterList().contains(paraName)) {
+                    if (value != null)
+                        value = value.replaceAll(Pattern.quote(CarbonConstants.CARBON_HOME_PARAMETER),
+                                CarbonUtils.getCarbonHome());
+                    h2PropertiesConfigured.put(paraName, value);
+                }
+            }
+            if (h2PropertiesConfigured.containsKey(H2Constants.PARA_WEB) ||
+                    h2PropertiesConfigured.containsKey(H2Constants.PARA_TCP) ||
+                    h2PropertiesConfigured.containsKey(H2Constants.PARA_PG)) {
+                h2Properties = h2PropertiesConfigured;
+            } else {
+                for (Iterator iterator = h2PropertiesConfigured.keySet().iterator(); iterator.hasNext(); ) {
+                    String paraName = (String) iterator.next();
+                    h2Properties.put(paraName, h2PropertiesConfigured.get(paraName));
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error while retrieving H2 properties from carbon context", e);
+        }
+        return h2Properties;
+    }
+
+    public static String getCarbonHome() {
+
+        String carbonHome = System.getProperty(CarbonConstants.CARBON_HOME);
+        if (carbonHome == null) {
+            carbonHome = System.getenv(CarbonConstants.CARBON_HOME_ENV);
+        }
+        return carbonHome;
+    }
+}

--- a/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/utils/H2Constants.java
+++ b/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/utils/H2Constants.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.h2.osgi.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Holds the H2 DB related constants.
+ */
+public class H2Constants {
+
+    public static final String PARA_WEB = "web";                            //Start the web server with the H2 Console
+    public static final String PARA_WEB_ALLOW_OTHERS = "webAllowOthers";    //Allow other computers to connect
+    public static final String PARA_WEB_PORT = "webPort";                   //The port (default: 8082)
+    public static final String PARA_WEB_SSL = "webSSL";                     //Use encrypted (HTTPS) connections
+    public static final String PARA_BROWSER = "browser";                    //Start a browser and open a page to connect to the web server
+    public static final String PARA_TCP = "tcp";                            //Start the TCP server
+    public static final String PARA_TCP_ALLOW_OTHERS = "tcpAllowOthers";    //Allow other computers to connect
+    public static final String PARA_TCP_PORT = "tcpPort";                   //The port (default: 9092)
+    public static final String PARA_TCP_SSL = "tcpSSL";                     //Use encrypted (SSL) connections
+    public static final String PARA_TCP_PASSWORD = "tcpPassword";           //The password for shutting down a TCP server
+    public static final String PARA_TCP_SHUTDOWN = "tcpShutdown";           //Stop the TCP server; example: tcp://localhost:9094
+    public static final String PARA_TCP_SHUTDOWN_FORCE = "tcpShutdownForce";//Do not wait until all connections are closed
+    public static final String PARA_PG = "pg";                              //Start the PG server
+    public static final String PARA_PG_ALLOW_OTHERS = "pgAllowOthers";      //Allow other computers to connect
+    public static final String PARA_PG_PORT = "pgPort";                     //The port (default: 5435)
+    public static final String PARA_BASE_DIR = "baseDir";                   //The base directory for H2 databases; for all servers
+    public static final String PARA_IF_EXISTS = "ifExists";                 //Only existing databases may be opened; for all servers
+    public static final String PARA_TRACE = "trace";                        //Print additional trace information; for all servers
+
+
+    public static final String ENGINE_VAR_DATABASES = "DATABASES";
+    public static final String ENGINE_METHOD_CLOSE = "close";
+
+    public static String[] getParameterStringList() {
+        return (String[]) getParameterList().toArray(new String[]{});
+    }
+
+    public static List getParameterList() {
+
+        List paraList = new ArrayList();
+        paraList.add(PARA_WEB);
+        paraList.add(PARA_WEB_ALLOW_OTHERS);
+        paraList.add(PARA_WEB_PORT);
+        paraList.add(PARA_WEB_SSL);
+        paraList.add(PARA_BROWSER);
+        paraList.add(PARA_TCP);
+        paraList.add(PARA_TCP_ALLOW_OTHERS);
+        paraList.add(PARA_TCP_PORT);
+        paraList.add(PARA_TCP_SSL);
+        paraList.add(PARA_PG);
+        paraList.add(PARA_PG_ALLOW_OTHERS);
+        paraList.add(PARA_PG_PORT);
+        paraList.add(PARA_BASE_DIR);
+        paraList.add(PARA_IF_EXISTS);
+        paraList.add(PARA_TRACE);
+        return paraList;
+    }
+}

--- a/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/utils/H2Utils.java
+++ b/h2-engine/2.2.224.wso2v2/src/main/java/org/wso2/carbon/h2/osgi/utils/H2Utils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.h2.osgi.utils;
+
+import java.util.Map;
+
+/**
+ * Utility class for H2 related functions.
+ */
+public class H2Utils {
+
+    /**
+     * Resets H2 properties to default values.
+     */
+    public static void resetToDefaultParameters(Map h2Properties) {
+
+        String carbonHome = CarbonUtils.getCarbonHome();
+        String[] defaultParameters = new String[]{H2Constants.PARA_BASE_DIR};
+        String[] defaultParametersValues = new String[]{carbonHome};
+        for (int i = 0; i < defaultParameters.length; i++) {
+            String para = defaultParameters[i];
+            String value = defaultParametersValues[i];
+            h2Properties.put(para, value);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose
- This PR fixes the package folder structure issue in h2-engine `2.2.224.wso2v1`. 
- In the above h2-engine version, `console` folder which should be situated inside the `wso2/carbon/h2/osgi` folder, is situated outside the said folder [1].

[1] - https://github.com/wso2/orbit/tree/master/h2-engine/2.2.224.wso2v1/src/main/java/org/console
