### PR TITLE
Add pdfbox-io as a orbit dependency to exclude sun.misc import

### DIFF
--- a/pdfbox-io/3.0.1.wso2v1/pom.xml
+++ b/pdfbox-io/3.0.1.wso2v1/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ Copyright (c) 2015, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.apache.pdfbox</groupId>
+    <artifactId>pdfbox-io</artifactId>
+    <version>3.0.1.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>org.apache.pdfbox-io</name>
+    <description>
+        This bundle will export packages from pdfbox-io libraries of org.apache.pdfbox
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox-io</artifactId>
+            <version>${version.pdfbox-io}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Automatic-Module-Name>org.apache.pdfbox.io</Automatic-Module-Name>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.apache.pdfbox.io.*;version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.apache.commons.logging;resolution:=optional,
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>src/test/resources/org/apache/pdfbox/io/*.txt</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <version.pdfbox-io>3.0.1</version.pdfbox-io>
+    </properties>
+
+</project>

--- a/pdfbox-io/3.0.1.wso2v1/pom.xml
+++ b/pdfbox-io/3.0.1.wso2v1/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- ~ Copyright (c) 2015, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~ Copyright (c) 2024, WSO2 LLC. (http://wso2.com) All Rights Reserved.
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Purpose

- For the dependency upgrade process of pdfbox to 3.0.1, there is an extra import needed for pdfbox-io dependency.
- As per the https://mvnrepository.com/artifact/org.apache.pdfbox/pdfbox-io this is a new requirement came for 3.x versions.
- In the pdfbox-io `MANIFEST.MF`, there is an additional import for sun-misc which is not been even used in the code itself.
- This gives an OSGi error as the sun.misc is not currently exported from any of the packages in the pack.
- Related to https://github.com/wso2/carbon-apimgt/pull/12251

## Implementation
- Removed the sun.misc dependency by orbiting the pdfbox-io