### PR TITLE
Add openapi-generator version 4.3.1.wso2v8

### DIFF
--- a/openapi-generator/4.3.1.wso2v8/pom.xml
+++ b/openapi-generator/4.3.1.wso2v8/pom.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.openapitools</groupId>
+    <artifactId>openapi-generator</artifactId>
+    <version>4.3.1.wso2v8</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - openapi-generator (org.openapitools)</name>
+    <description>
+        This bundle will export packages from openapi-generator libraries of org.openapitools
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>openapi-generator</artifactId>
+            <version>6.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+            <version>${slf4j.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>0.11.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            !io.swagger.models.*,
+                            !io.swagger.annotations.*,
+                            !io.swagger.v3.*,
+                            !com.google.common.base,
+                            !com.google.common.collect,
+                            Ada;version="${export.pkg.version.swagger-codegen}",
+                            C-libcurl;version="${export.pkg.version.swagger-codegen}",
+                            Eiffel.*;version="${export.pkg.version.swagger-codegen}",
+                            Groovy;version="${export.pkg.version.swagger-codegen}",
+                            Java.*;version="${export.pkg.version.swagger-codegen}",
+                            JavaInflector;version="${export.pkg.version.swagger-codegen}",
+                            JavaJaxRS.*;version="${export.pkg.version.swagger-codegen}",
+                            JavaPlayFramework;version="${export.pkg.version.swagger-codegen}",
+                            JavaSpring.*;version="${export.pkg.version.swagger-codegen}",
+                            JavaVertXServer;version="${export.pkg.version.swagger-codegen}",
+                            Javascript;version="${export.pkg.version.swagger-codegen}",
+                            Javascript-Closure-Angular.*;version="${export.pkg.version.swagger-codegen}",
+                            Javascript-Flowtyped;version="${export.pkg.version.swagger-codegen}",
+                            Javascript.es6;version="${export.pkg.version.swagger-codegen}",
+                            Javascript.libraries.javascript;version="${export.pkg.version.swagger-codegen}",
+                            _common;version="${export.pkg.version.swagger-codegen}",
+                            android.*;version="${export.pkg.version.swagger-codegen}",
+                            apache2;version="${export.pkg.version.swagger-codegen}",
+                            apex;version="${export.pkg.version.swagger-codegen}",
+                            aspnetcore.*;version="${export.pkg.version.swagger-codegen}",
+                            bash;version="${export.pkg.version.swagger-codegen}",
+                            clojure;version="${export.pkg.version.swagger-codegen}",
+                            codegen;version="${export.pkg.version.swagger-codegen}",
+                            config;version="${export.pkg.version.swagger-codegen}",
+                            confluenceWikiDocs;version="${export.pkg.version.swagger-codegen}",
+                            cpp-pistache-server;version="${export.pkg.version.swagger-codegen}",
+                            cpp-qt5-client;version="${export.pkg.version.swagger-codegen}",
+                            cpp-qt5-qhttpengine-server;version="${export.pkg.version.swagger-codegen}",
+                            cpp-rest-sdk-client;version="${export.pkg.version.swagger-codegen}",
+                            cpp-restbed-server;version="${export.pkg.version.swagger-codegen}",
+                            cpp-tizen-client;version="${export.pkg.version.swagger-codegen}",
+                            csharp;version="${export.pkg.version.swagger-codegen}",
+                            csharp-dotnet2;version="${export.pkg.version.swagger-codegen}",
+                            csharp-nancyfx;version="${export.pkg.version.swagger-codegen}",
+                            csharp-netcore;version="${export.pkg.version.swagger-codegen}",
+                            dart;version="${export.pkg.version.swagger-codegen}",
+                            dart-jaguar;version="${export.pkg.version.swagger-codegen}",
+                            dart-jaguar.auth;version="${export.pkg.version.swagger-codegen}",
+                            dart.auth;version="${export.pkg.version.swagger-codegen}",
+                            dart2.*;version="${export.pkg.version.swagger-codegen}",
+                            dart2.auth;version="${export.pkg.version.swagger-codegen}",
+                            elixir;version="${export.pkg.version.swagger-codegen}",
+                            elm;version="${export.pkg.version.swagger-codegen}",
+                            erlang-client;version="${export.pkg.version.swagger-codegen}",
+                            erlang-proper;version="${export.pkg.version.swagger-codegen}",
+                            erlang-server;version="${export.pkg.version.swagger-codegen}",
+                            flash;version="${export.pkg.version.swagger-codegen}",
+                            fsharp-giraffe-server;version="${export.pkg.version.swagger-codegen}",
+                            go;version="${export.pkg.version.swagger-codegen}",
+                            go-gin-server;version="${export.pkg.version.swagger-codegen}",
+                            go-server;version="${export.pkg.version.swagger-codegen}",
+                            graphql-nodejs-express-server;version="${export.pkg.version.swagger-codegen}",
+                            graphql-schema;version="${export.pkg.version.swagger-codegen}",
+                            haskell-http-client.*;version="${export.pkg.version.swagger-codegen}",
+                            haskell-servant;version="${export.pkg.version.swagger-codegen}",
+                            htmlDocs;version="${export.pkg.version.swagger-codegen}",
+                            htmlDocs2;version="${export.pkg.version.swagger-codegen}",
+                            java-msf4j-server;version="${export.pkg.version.swagger-codegen}",
+                            java-pkmst.*;version="${export.pkg.version.swagger-codegen}",
+                            java-undertow-server;version="${export.pkg.version.swagger-codegen}",
+                            jmeter-client;version="${export.pkg.version.swagger-codegen}",
+                            kotlin-client.*;version="${export.pkg.version.swagger-codegen}",
+                            kotlin-server.*;version="${export.pkg.version.swagger-codegen}",
+                            kotlin-spring.*;version="${export.pkg.version.swagger-codegen}",
+                            lua;version="${export.pkg.version.swagger-codegen}",
+                            mysql-schema;version="${export.pkg.version.swagger-codegen}",
+                            nodejs;version="${export.pkg.version.swagger-codegen}",
+                            objc;version="${export.pkg.version.swagger-codegen}",
+                            openapi;version="${export.pkg.version.swagger-codegen}",
+                            openapi-static;version="${export.pkg.version.swagger-codegen}",
+                            openapi-static.assets.css;version="${export.pkg.version.swagger-codegen}",
+                            openapi-static.assets.images;version="${export.pkg.version.swagger-codegen}",
+                            openapi-static.assets.js;version="${export.pkg.version.swagger-codegen}",
+                            openapi-yaml;version="${export.pkg.version.swagger-codegen}",
+                            perl;version="${export.pkg.version.swagger-codegen}",
+                            php;version="${export.pkg.version.swagger-codegen}",
+                            php-laravel.*;version="${export.pkg.version.swagger-codegen}",
+                            php-lumen;version="${export.pkg.version.swagger-codegen}",
+                            php-silex;version="${export.pkg.version.swagger-codegen}",
+                            php-slim-server;version="${export.pkg.version.swagger-codegen}",
+                            php-symfony.*;version="${export.pkg.version.swagger-codegen}",
+                            php-ze-ph;version="${export.pkg.version.swagger-codegen}",
+                            powershell;version="${export.pkg.version.swagger-codegen}",
+                            python.*;version="${export.pkg.version.swagger-codegen}",
+                            python-aiohttp;version="${export.pkg.version.swagger-codegen}",
+                            python-blueplanet.*;version="${export.pkg.version.swagger-codegen}",
+                            python-flask;version="${export.pkg.version.swagger-codegen}",
+                            python-prior.*;version="${export.pkg.version.swagger-codegen}",
+                            r;version="${export.pkg.version.swagger-codegen}",
+                            ruby-client;version="${export.pkg.version.swagger-codegen}",
+                            ruby-on-rails-server;version="${export.pkg.version.swagger-codegen}",
+                            ruby-sinatra-server;version="${export.pkg.version.swagger-codegen}",
+                            rust.*;version="${export.pkg.version.swagger-codegen}",
+                            rust-server;version="${export.pkg.version.swagger-codegen}",
+                            scala-akka-client;version="${export.pkg.version.swagger-codegen}",
+                            scala-finch.*;version="${export.pkg.version.swagger-codegen}",
+                            scala-gatling;version="${export.pkg.version.swagger-codegen}",
+                            scala-httpclient;version="${export.pkg.version.swagger-codegen}",
+                            scala-lagom-server;version="${export.pkg.version.swagger-codegen}",
+                            scala-play-server.*;version="${export.pkg.version.swagger-codegen}",
+                            scalatra.*;version="${export.pkg.version.swagger-codegen}",
+                            scalaz;version="${export.pkg.version.swagger-codegen}",
+                            swift;version="${export.pkg.version.swagger-codegen}",
+                            swift3;version="${export.pkg.version.swagger-codegen}",
+                            swift4;version="${export.pkg.version.swagger-codegen}",
+                            swift5.*;version="${export.pkg.version.swagger-codegen}",
+                            typescript-angular;version="${export.pkg.version.swagger-codegen}",
+                            typescript-angularjs;version="${export.pkg.version.swagger-codegen}",
+                            typescript-aurelia;version="${export.pkg.version.swagger-codegen}",
+                            typescript-axios;version="${export.pkg.version.swagger-codegen}",
+                            typescript-fetch;version="${export.pkg.version.swagger-codegen}",
+                            typescript-inversify;version="${export.pkg.version.swagger-codegen}",
+                            typescript-jquery;version="${export.pkg.version.swagger-codegen}",
+                            typescript-node;version="${export.pkg.version.swagger-codegen}",
+                            typescript-rxjs;version="${export.pkg.version.swagger-codegen}",
+                            validator;version="${export.pkg.version.swagger-codegen}",
+                            org.openapitools.codegen.*;version="${export.pkg.version.swagger-codegen}";-split-package:=merge-first,,
+                            org.openapitools.codegen.templating.*;version="${export.pkg.version.swagger-codegen}"
+                        </Export-Package>
+                        <Import-Package>
+                            io.swagger.v3.*;version="${import.openapitools.parser.version.range}",
+                            io.swagger.parser.*;version="${import.openapitools.parser.version.range}",
+                            com.fasterxml.jackson.datatype.guava; version="${jackson.version.range}",
+                            com.google.common.*; version="${google.version.range}",
+                            org.slf4j.ext,
+                            *.;resolution=optional
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Include-Resource>
+                            {maven-resources},
+                            @openapi-generator-6.6.0.jar!/META-INF/services/*
+                        </Include-Resource>
+                        <_exportcontents>
+                            com.github.jknack.handlebars,
+                            com.github.jknack.handlebars.context,
+                            com.github.jknack.handlebars.helper,
+                            com.github.jknack.handlebars.io,
+                            com.google.common.base,
+                            com.google.common.collect,
+                            com.google.common.io,
+                            com.mifmif.common.regex,
+                            org.commonmark.node,
+                            org.commonmark.parser,
+                            org.commonmark.renderer.html,
+                            org.slf4j.ext
+                        </_exportcontents>
+                        <Embed-Dependency>
+                            slf4j-ext;scope=compile|runtime;inline=false,
+                            commonmark;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <export.pkg.version.swagger-codegen>4.3.1.wso2v8</export.pkg.version.swagger-codegen>
+        <import.pkg.version.swagger-codegen>6.6.0</import.pkg.version.swagger-codegen>
+        <jmustache-version>1.14</jmustache-version>
+        <handlebars.java-version>4.1.2</handlebars.java-version>
+        <slf4j.api.version>1.7.36</slf4j.api.version>
+        <commons-io-version>2.11.0</commons-io-version>
+        <jackson.version.range>[2.7.0,3.0.0)</jackson.version.range>
+        <google.version.range>[33.0.0,34.0.0)</google.version.range>
+        <slf4j.version.range>[1.7.0,1.8.0)</slf4j.version.range>
+        <import.openapitools.parser.version.range>[2.0, 3.0)</import.openapitools.parser.version.range>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/swagger-parser/2.1.18.wso2v2/pom.xml
+++ b/swagger-parser/2.1.18.wso2v2/pom.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.io.swagger.v3</groupId>
+    <artifactId>swagger-parser</artifactId>
+    <version>2.1.18.wso2v2</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - swagger-parser (io.swagger)</name>
+    <description>
+        This bundle will export packages from swagger-parser libraries of io.swagger
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>2.1.18</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser-v2-converter</artifactId>
+            <version>2.1.18</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser-v3</artifactId>
+            <version>2.1.18</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>2.2.9</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-models</artifactId>
+            <version>2.2.9</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.0</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson-version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson-version}</version>
+            <optional>true</optional>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.swagger.v3.*;version="${export.pkg.version.swagger-parser}",
+                            io.swagger.v3.parser.*;version="${export.pkg.version.swagger-parser}",
+                            io.swagger.v3.parser.core.*;version="${export.pkg.version.swagger-parser}",
+                            io.swagger.v3.parser.converter.*;version="${export.pkg.version.swagger-parser}",
+                            io.swagger.parser.*;version="${export.pkg.version.swagger-parser}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.slf4j; version="${slf4j.import.version.range}",
+                            org.apache.commons.lang3.builder; version="${commons.lang.version.range}",
+                            org.apache.commons.lang3; version="${commons.lang.version.range}",
+                            javax.net.ssl; version="0.0.0",
+                            io.swagger.util; version="${io.swagger.version.range}",
+                            io.swagger.models.refs; version="${io.swagger.version.range}",
+                            io.swagger.models.properties; version="${io.swagger.version.range}",
+                            io.swagger.models.parameters; version="${io.swagger.version.range}",
+                            io.swagger.models.auth; version="${io.swagger.version.range}",
+                            io.swagger.models; version="${io.swagger.version.range}",
+                            io.swagger.v3.oas.models; version="${io.swagger.v3.version.range}",
+                            com.fasterxml.jackson.*; version="${jackson.version.range}",
+                            org.apache.commons.io;version="${commons.io.version.range}",
+                            org.apache.commons.io.comparator;version="${commons.io.version.range}",
+                            org.apache.commons.io.filefilter;version="${commons.io.version.range}",
+                            org.apache.commons.io.input;version="${commons.io.version.range}",
+                            org.apache.commons.io.output;version="${commons.io.version.range}",
+                            org.yaml.snakeyaml.*;version="${snakeyaml.version.range}",
+                            .*;resolution=optional
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Include-Resource>
+                            {maven-resources},
+                            @swagger-parser-*.jar!/META-INF/*
+                        </Include-Resource>
+                        <Embed-Dependency>
+                            commons-io;scope=compile|runtime;inline=false,
+                            swagger-models;scope=compile|runtime;inline=false,
+                            swagger-core;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <export.pkg.version.swagger-parser>2.1.18.wso2v2</export.pkg.version.swagger-parser>
+        <io.swagger.version.range>[1.6.1,1.7)</io.swagger.version.range>
+        <io.swagger.v3.version.range>[2.1.2,3.0)</io.swagger.v3.version.range>
+        <jackson.version.range>[2.7.0,3.0.0)</jackson.version.range>
+        <javax.xml.bind.version.range>[2.3.2,3.0.0)</javax.xml.bind.version.range>
+        <slf4j.import.version.range>[1.7.0, 1.8.0)</slf4j.import.version.range>
+        <commons.io.version.range>[2.6,3.0)</commons.io.version.range>
+        <commons.lang.version.range>[3.2.1,4)</commons.lang.version.range>
+        <snakeyaml.version.range>[1.30,3.00)</snakeyaml.version.range>
+        <jackson-version>2.16.1</jackson-version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/swagger-request-validator/2.12.1.wso2v3/pom.xml
+++ b/swagger-request-validator/2.12.1.wso2v3/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.atlassian.oai</groupId>
+    <artifactId>swagger-request-validator-core</artifactId>
+    <version>2.12.1.wso2v3</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - swagger-request-validator-core (swagger-request-validator)</name>
+    <description>
+        This bundle will export packages from swagger-request-validator-core libraries of swagger-request-validator
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.atlassian.oai</groupId>
+            <artifactId>swagger-request-validator-core</artifactId>
+            <version>${swagger-request-validator.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.github.java-json-tools</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>${json-schema-validator-version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${apache-felix-plugin-version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.atlassian.oai.validator;version="${swagger-request-validator.version}";
+                            com.atlassian.oai.validator.interaction;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.interaction.request;
+                            version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.interaction.response;
+                            version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.model;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.report;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.schema;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.schema.format;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.schema.keyword;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.schema.transform;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.util;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.whitelist;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.whitelist.rule;version="${swagger-request-validator.version}";,
+                            com.atlassian.oai.validator.model.Request;version="${swagger-request-validator.version}";
+                            swagger.validation;version="${swagger-request-validator.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            com.fasterxml.jackson.core; version="${jackson-version-range}",
+                            com.fasterxml.jackson.databind; version="${jackson-version-range}",
+                            com.fasterxml.jackson.databind.node; version="${jackson-version-range}",
+                            com.github.fge; version="${fge-base-version}",
+                            com.github.fge.jackson; version="${fge-jackson-version}",
+                            com.github.fge.jackson.jsonpointer; version="${fge-jackson-version}",
+                            com.github.fge.jsonschema; version="${fge-jsonschema-version}",
+                            com.github.fge.jsonschema.core.exceptions; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.keyword.syntax; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.keyword.syntax.checkers;
+                            version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.keyword.syntax.dictionaries;
+                            version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.load; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.load.configuration;
+                            version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.load.download; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.load.uri; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.messages; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.processing; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.ref; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.report; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.tree; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.tree.key; version="${fge-jsonschema-version-range}",
+                            com.github.fge.jsonschema.core.util; version="${fge-jsonschema-version-range}",
+                            com.github.fge.msgsimple.bundle; version="${msg.simple.version}",
+                            com.github.fge.msgsimple.load; version="${msg.simple.version}",
+                            com.github.fge.uritemplate; version="${uri-template-version}",
+                            com.google.common.base; version="${com.google.common.imp.pkg.version}",
+                            com.google.common.cache; version="${com.google.common.imp.pkg.version}",
+                            com.google.common.collect; version="${com.google.common.imp.pkg.version}",
+                            com.google.common.net; version="${com.google.common.imp.pkg.version}",
+                            com.google.i18n.phonenumbers; version="${com.google.i18n.phonenumbers.version}",
+                            io.swagger.parser; version="${io.swagger.v3.oas.models.version}",
+                            io.swagger.util; version="${io-swagger-version}",
+                            io.swagger.v3.oas.models; version="${io.swagger.v3.oas.models.version}",
+                            io.swagger.v3.oas.models.media; version="${io.swagger.v3.oas.models.version}",
+                            io.swagger.v3.oas.models.parameters; version="${io.swagger.v3.oas.models.version}",
+                            io.swagger.v3.oas.models.responses; version="${io.swagger.v3.oas.models.version}",
+                            io.swagger.v3.oas.models.security; version="${io.swagger.v3.oas.models.version}",
+                            io.swagger.v3.oas.models.servers; version="${io.swagger.v3.oas.models.version}",
+                            io.swagger.v3.oas.models.headers; version="${io.swagger.v3.oas.models.version}",
+                            io.swagger.v3.parser.core.models; version="${io.swagger.v3.oas.models.version}",
+                            javax.mail.internet; version="${javax.mail.internet.imp.pkg.version.range}",
+                            org.apache.commons.io; version="${commons-io-version-range}",
+                            org.apache.commons.lang3; version="${commons-lang3.import.version}",
+                            org.apache.commons.lang3.tuple; version="${commons-lang3.import.version}",
+                            org.joda.time; version="${org.joda.time.imp.pkg.version.range}",
+                            org.joda.time.format; version="${org.joda.time.imp.pkg.version.range}",
+                            org.slf4j; version="${slf4j-version-range}"
+                        </Import-Package>
+                        <Embed-Dependency>
+                            json-schema-validator;version=${json-schema-validator-version};scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <swagger-request-validator.version>2.12.1</swagger-request-validator.version>
+        <json-schema-validator-version>2.2.11</json-schema-validator-version>
+        <io-swagger-version>1.6.1</io-swagger-version>
+        <apache-felix-plugin-version>3.3.0</apache-felix-plugin-version>
+        <msg.simple.version>1.1.0</msg.simple.version>
+        <com.google.common.imp.pkg.version>33.0.0</com.google.common.imp.pkg.version>
+        <com.google.i18n.phonenumbers.version>7.4.2</com.google.i18n.phonenumbers.version>
+        <jackson-version-range>[2.10, 3)</jackson-version-range>
+        <javax.mail.internet.imp.pkg.version.range>[1.6.2,2)</javax.mail.internet.imp.pkg.version.range>
+        <org.joda.time.imp.pkg.version.range>[2.9.4, 3.0.0)</org.joda.time.imp.pkg.version.range>
+        <commons-lang3.import.version>[3.10.0, 3.11.0)</commons-lang3.import.version>
+        <io.swagger.v3.oas.models.version>2.0.20.wso2v1</io.swagger.v3.oas.models.version>
+        <uri-template-version>0.9.0</uri-template-version>
+        <fge-base-version>1.2.0</fge-base-version>
+        <fge-jsonschema-version-range>[1.2.8, 1.3.0)</fge-jsonschema-version-range>
+        <fge-jsonschema-version>2.2.6</fge-jsonschema-version>
+        <fge-jackson-version>1.8.0</fge-jackson-version>
+        <slf4j-version-range>[1.7.29,2)</slf4j-version-range>
+        <commons-io-version-range>[1.4.9999,1.5.0)</commons-io-version-range>
+    </properties>
+</project>


### PR DESCRIPTION
### Purpose
To ensure compatibility with the latest non-vulnerable version of Guava 33.0.