### PR TITLE
create mime4j-core

### DIFF
--- a/mime4j-core/0.8.10.wso2v1/pom.xml
+++ b/mime4j-core/0.8.10.wso2v1/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ Copyright (c) 2024, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.apache.james</groupId>
+    <artifactId>apache-mime4j-core</artifactId>
+    <version>0.8.10.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Mime4j Core</name>
+    <description>
+        This bundle will export packages from apache-mime4j-core libraries of org.apache.james
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-core</artifactId>
+            <version>${version.mime4j-core}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${version.commons-io}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.apache.james.mime4j.*;version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.apache.commons.io.output;version="${version.commons-io}",
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <version.mime4j-core>0.8.10</version.mime4j-core>
+        <version.commons-io>[2.11.0, 3.0.0)</version.commons-io>
+    </properties>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <module>jaxws-ri/2.3.2.wso2v1</module>
         <module>jta/1.1.0.wso2v1</module>
         <module>jta/1.1.0.wso2v2</module>
+        <module>mime4j-core/0.8.10.wso2v1</module>
         <module>tomcat/7.0.93.wso2v1</module>
         <module>tomcat-catalina-ha/7.0.93.wso2v1</module>
         <module>tomcat-el-api/7.0.93.wso2v1</module>


### PR DESCRIPTION
## Purpose
Create Mime4j-core  0.8.10 orbit bundle due to maven jar having incorrect import version ranges.
Part of the fix for issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/5662