### PR TITLE
Add new version to azure-messaging-servicebus-sdk-all : 7.14.6.wso2v2

### DIFF
--- a/azure-messaging-servicebus-sdk-all/7.14.6.wso2v1/pom.xml
+++ b/azure-messaging-servicebus-sdk-all/7.14.6.wso2v1/pom.xml
@@ -63,9 +63,19 @@
                             com.azure.core.amqp.*;version="${com.azure.core.amqp.version}",
                             com.azure.core.exception.*;version="${com.azure.core.version}",
                             com.azure.core.util.serializer.*;version="${com.azure.core.version}",
-                            com.azure.core.util;version="${com.azure.core.util.version}"
+                            com.azure.core.util;version="${com.azure.core.util.version}",
+                            com.azure.core.http.netty.*;version="${com.azure.core.http.netty.version}",
+                            reactor.netty.*; version="${reactor.netty.version}",
+                            io.netty.resolver.dns.*; version="${io.netty.version}",
+                            io.netty.codec.http2.*; version="${io.netty.version}",
+                            io.netty.handler.codec.http2.*; version="${io.netty.version}",
+                            io.netty.channel.unix.*; version="${io.netty.version}",
                         </Export-Package>
-                        <Import-Package/>
+                        <Import-Package>
+                            !com.azure.messaging.servicebus.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                         <Private-Package>
                             com.azure.*,
                             com.fasterxml.*,
@@ -85,5 +95,8 @@
         <com.azure.core.amqp.version>2.8.13</com.azure.core.amqp.version>
         <com.azure.core.version>1.45.0</com.azure.core.version>
         <com.azure.core.util.version>1.45.0</com.azure.core.util.version>
+        <com.azure.core.http.netty.version>1.13.10</com.azure.core.http.netty.version>
+        <reactor.netty.version>1.0.38</reactor.netty.version>
+        <io.netty.version>4.1.100.Final</io.netty.version>
     </properties>
 </project>

--- a/azure-messaging-servicebus-sdk-all/7.14.6.wso2v2/pom.xml
+++ b/azure-messaging-servicebus-sdk-all/7.14.6.wso2v2/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  ~
  ~ WSO2 Inc. licenses this file to you under the Apache License,
  ~ Version 2.0 (the "License"); you may not use this file except

--- a/azure-messaging-servicebus-sdk-all/7.14.6.wso2v2/pom.xml
+++ b/azure-messaging-servicebus-sdk-all/7.14.6.wso2v2/pom.xml
@@ -75,7 +75,6 @@
                             !com.azure.messaging.servicebus.*,
                             *;resolution:=optional
                         </Import-Package>
-                        <DynamicImport-Package>*</DynamicImport-Package>
                         <Private-Package>
                             com.azure.*,
                             com.fasterxml.*,

--- a/azure-messaging-servicebus-sdk-all/7.14.6.wso2v2/pom.xml
+++ b/azure-messaging-servicebus-sdk-all/7.14.6.wso2v2/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.orbit.com.azure</groupId>
     <artifactId>azure-messaging-servicebus-sdk-all</artifactId>
-    <version>7.14.6.wso2v1</version>
+    <version>7.14.6.wso2v2</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon Orbit - azure-messaging-servicebus-sdk-all</name>
     <description>
@@ -63,9 +63,19 @@
                             com.azure.core.amqp.*;version="${com.azure.core.amqp.version}",
                             com.azure.core.exception.*;version="${com.azure.core.version}",
                             com.azure.core.util.serializer.*;version="${com.azure.core.version}",
-                            com.azure.core.util;version="${com.azure.core.util.version}"
+                            com.azure.core.util;version="${com.azure.core.util.version}",
+                            com.azure.core.http.netty.*;version="${com.azure.core.http.netty.version}",
+                            reactor.netty.*; version="${reactor.netty.version}",
+                            io.netty.resolver.dns.*; version="${io.netty.version}",
+                            io.netty.codec.http2.*; version="${io.netty.version}",
+                            io.netty.handler.codec.http2.*; version="${io.netty.version}",
+                            io.netty.channel.unix.*; version="${io.netty.version}",
                         </Export-Package>
-                        <Import-Package/>
+                        <Import-Package>
+                            !com.azure.messaging.servicebus.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                         <Private-Package>
                             com.azure.*,
                             com.fasterxml.*,
@@ -85,5 +95,8 @@
         <com.azure.core.amqp.version>2.8.13</com.azure.core.amqp.version>
         <com.azure.core.version>1.45.0</com.azure.core.version>
         <com.azure.core.util.version>1.45.0</com.azure.core.util.version>
+        <com.azure.core.http.netty.version>1.13.10</com.azure.core.http.netty.version>
+        <reactor.netty.version>1.0.38</reactor.netty.version>
+        <io.netty.version>4.1.100.Final</io.netty.version>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose

Export transitive dependencies required for admin client in azure-messaging-servicebus-sdk-all.
