### PR TITLE
Add solr 5.5.5.wso2v4 dependency with updated commons.io version range

### DIFF
--- a/solr/5.5.5.wso2v4/pom.xml
+++ b/solr/5.5.5.wso2v4/pom.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
+  ~
+  ~ This software is the property of WSO2 Inc. and its suppliers, if any.
+  ~ Dissemination of any information or reproduction of any material contained
+  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>bundle</packaging>
+    <groupId>org.wso2.orbit.org.apache.solr</groupId>
+    <artifactId>solr</artifactId>
+    <version>${orbit.version.solr}</version>
+    <name>solr.wso2</name>
+    <description>
+        This bundle will represent solr and lucene jars
+    </description>
+
+    <repositories>
+        <repository>
+            <id>maven.restlet.org</id>
+            <name>Restlet maven repository</name>
+            <url>https://maven.restlet.talend.com</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-core</artifactId>
+            <version>${version.solr}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-fileupload</groupId>
+                    <artifactId>commons-fileupload</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>woodstox</groupId>
+                    <artifactId>wstx-asl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-solrj</artifactId>
+            <version>${version.solr}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>wstx-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-fileupload</groupId>
+                    <artifactId>commons-fileupload</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <version>${maven.bundle.plugin.version}</version>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.apache.solr.*;version="${version.solr}"
+                        </Export-Package>
+                        <Import-Package>
+                            !org.apache.solr.*,
+                            org.apache.lucene.*; version="${version.lucene}",
+                            org.apache.commons.io.*;version="${version.commons.io}",
+                            org.apache.zookeeper.*;version="${version.zookeeper}",
+                            org.noggit.*;version="${version.noggit}",
+                            com.spatial4j.*;version="${version.spatial4j}",
+                            org.restlet.*;version="${version.restlet}"
+                        </Import-Package>
+                        <Private-Package></Private-Package>
+                        <Embed-Dependency>
+                            solr-solrj;scope=compile|runtime;inline=true,
+                        </Embed-Dependency>
+                        <!--Dynamic imports enabled here because solr uses dynamic class loading to import lucene -->
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <version.solr>5.5.5</version.solr>
+        <version.lucene>[5.2.1,5.6.0)</version.lucene>
+        <orbit.version.solr>${version.solr}.wso2v4</orbit.version.solr>
+        <version.noggit>[0.6,0.7)</version.noggit>
+        <version.commons.io>[2.4.0,3.0.0)</version.commons.io>
+        <version.zookeeper>[3.3.4,3.5.0)</version.zookeeper>
+        <version.spatial4j>[0.4.1,0.5)</version.spatial4j>
+        <version.restlet>[2.3.0,2.4.0)</version.restlet>
+        <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <http.version>[4.3.0,4.4.0)</http.version>
+    </properties>
+</project>

--- a/solr/5.5.5.wso2v4/pom.xml
+++ b/solr/5.5.5.wso2v4/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
+  ~ Copyright (c) 2024, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
   ~
   ~ This software is the property of WSO2 Inc. and its suppliers, if any.
   ~ Dissemination of any information or reproduction of any material contained


### PR DESCRIPTION
## Purpose
This PR adds the Solr version 5.5.5.wso2v4 updated commons.io version range.

## Related Issues
https://github.com/wso2-enterprise/wso2-apim-internal/issues/7371
