### PR TITLE
Add swagger-parser 2.1.18.wso2v4 with commons-io version upgrade

### DIFF
--- a/swagger-parser/2.1.18.wso2v4/pom.xml
+++ b/swagger-parser/2.1.18.wso2v4/pom.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.io.swagger.v3</groupId>
+    <artifactId>swagger-parser</artifactId>
+    <version>2.1.18.wso2v4</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - swagger-parser (io.swagger)</name>
+    <description>
+        This bundle will export packages from swagger-parser libraries of io.swagger
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>2.1.18</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser-v2-converter</artifactId>
+            <version>2.1.18</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser-v3</artifactId>
+            <version>2.1.18</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>2.2.9</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-models</artifactId>
+            <version>2.2.9</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.0</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson-version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson-version}</version>
+            <optional>true</optional>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.swagger.v3.*;version="${export.pkg.version.swagger-parser}",
+                            io.swagger.v3.parser.*;version="${export.pkg.version.swagger-parser}",
+                            io.swagger.v3.parser.core.*;version="${export.pkg.version.swagger-parser}",
+                            io.swagger.v3.parser.converter.*;version="${export.pkg.version.swagger-parser}",
+                            io.swagger.parser.*;version="${export.pkg.version.swagger-parser}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.slf4j; version="${slf4j.import.version.range}",
+                            org.apache.commons.lang3.builder; version="${commons.lang.version.range}",
+                            org.apache.commons.lang3; version="${commons.lang.version.range}",
+                            javax.net.ssl; version="0.0.0",
+                            io.swagger.util; version="${io.swagger.version.range}",
+                            io.swagger.models.refs; version="${io.swagger.version.range}",
+                            io.swagger.models.properties; version="${io.swagger.version.range}",
+                            io.swagger.models.parameters; version="${io.swagger.version.range}",
+                            io.swagger.models.auth; version="${io.swagger.version.range}",
+                            io.swagger.models; version="${io.swagger.version.range}",
+                            io.swagger.v3.oas.models; version="${io.swagger.v3.version.range}",
+                            com.fasterxml.jackson.*; version="${jackson.version.range}",
+                            org.apache.commons.io;version="${commons.io.version.range}",
+                            org.apache.commons.io.comparator;version="${commons.io.version.range}",
+                            org.apache.commons.io.filefilter;version="${commons.io.version.range}",
+                            org.apache.commons.io.input;version="${commons.io.version.range}",
+                            org.apache.commons.io.output;version="${commons.io.version.range}",
+                            org.yaml.snakeyaml.*;version="${snakeyaml.version.range}",
+                            .*;resolution=optional
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Include-Resource>
+                            {maven-resources},
+                            @swagger-parser-*.jar!/META-INF/*
+                        </Include-Resource>
+                        <Embed-Dependency>
+                            swagger-models;scope=compile|runtime;inline=false,
+                            swagger-core;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <export.pkg.version.swagger-parser>2.1.18.wso2v4</export.pkg.version.swagger-parser>
+        <io.swagger.version.range>[1.6.1,1.7)</io.swagger.version.range>
+        <io.swagger.v3.version.range>[2.1.2,3.0)</io.swagger.v3.version.range>
+        <jackson.version.range>[2.7.0,3.0.0)</jackson.version.range>
+        <javax.xml.bind.version.range>[2.3.2,3.0.0)</javax.xml.bind.version.range>
+        <slf4j.import.version.range>[1.7.0, 1.8.0)</slf4j.import.version.range>
+        <commons.io.version.range>[2.6,3.0)</commons.io.version.range>
+        <commons.lang.version.range>[3.2.1,4)</commons.lang.version.range>
+        <snakeyaml.version.range>[1.30,3.00)</snakeyaml.version.range>
+        <jackson-version>2.16.1</jackson-version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>


### PR DESCRIPTION
### Purpose

To add swagger-parser 2.1.18.wso2v4 with commons-io version upgrade.