### PR TITLE
Revert "Add netty-resolver-dns-native-macos runtime dependency to netty-all"

### DIFF
--- a/netty/4.1.115.wso2v1/pom.xml
+++ b/netty/4.1.115.wso2v1/pom.xml
@@ -42,19 +42,6 @@
             <artifactId>netty-all</artifactId>
             <version>${io.netty.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>${io.netty.version}</version>
-            <classifier>osx-aarch_64</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>${io.netty.version}</version>
-            <classifier>osx-x86_64</classifier>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -78,8 +65,6 @@
                             *;resolution:=optional
                         </Import-Package>
                         <Include-Resource>
-                            @netty-resolver-dns-native-macos-${io.netty.version}-osx-aarch_64.jar!/META-INF/**,
-                            @netty-resolver-dns-native-macos-${io.netty.version}-osx-x86_64.jar!/META-INF/**,
                             {maven-resources}
                         </Include-Resource>
                     </instructions>


### PR DESCRIPTION
Reverts wso2/orbit#1180

Need to release this orbit in different version