### PR TITLE
Add BouncyCastle 1.80

### DIFF
--- a/bcpkix/1.80.0.wso2v1/pom.xml
+++ b/bcpkix/1.80.0.wso2v1/pom.xml
@@ -1,0 +1,164 @@
+<!--
+ ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+    <artifactId>bcpkix-jdk18on</artifactId>
+    <packaging>bundle</packaging>
+    <name>bcpkix</name>
+    <version>1.80.0.wso2v1</version>
+    <description>
+        This bundle will represent bouncycastle PKIX 1.80
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${version.bc}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bcpkix-jdk18on
+             library as a transitive dependency. This is required because we are embedding bcpkix-jdk18on library inside
+             this orbit bundle without extracting the content, because bcpkix-jdk18on library is signed. If you embed a
+             dependency and set optional to true, then dependent projects will not be able to compile their source
+             with this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
+            <version>${version.bc}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bcutil-jdk18on
+             library as a transitive dependency. This is required because we are embedding bcutil-jdk18on library inside
+             this orbit bundle without extracting the content, because bcutil-jdk18on library is signed. If you embed a
+             dependency and set optional to true, then dependent projects will not be able to compile their source
+             with this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Import-Package>
+                            org.bouncycastle.x509.*;version="${imp.pkg.version.range.bcprov}",
+                            org.bouncycastle.util.*;version="${imp.pkg.version.range.bcprov}",
+                            org.bouncycastle.math.*;version="${imp.pkg.version.range.bcprov}",
+                            org.bouncycastle.jce.*;version="${imp.pkg.version.range.bcprov}",
+                            org.bouncycastle.jcajce.*;version="${imp.pkg.version.range.bcprov}",
+                            org.bouncycastle.crypto.*;version="${imp.pkg.version.range.bcprov}",
+                            org.bouncycastle.asn1.*;version="${imp.pkg.version.range.bcprov}",
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>bcpkix-jdk18on;scope=compile|runtime;inline=false,
+                            bcutil-jdk18on;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                        <_exportcontents>
+                            org.bouncycastle.cert;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cert.bc;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cert.cmp;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cert.crmf;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cert.crmf.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cert.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cert.ocsp;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cert.ocsp.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cert.selector;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cert.selector.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cms;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cms.bc;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.cms.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.dvcs;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.eac;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.eac.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.eac.operator;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.eac.operator.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.mozilla;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.openssl;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.openssl.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.operator;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.operator.bc;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.operator.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.pkcs;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.pkcs.bc;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.pkcs.jcajce;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.tsp;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.tsp.cms;version="${exp.pkg.version.bcpkix}",
+                            org.bouncycastle.voms;version="${exp.pkg.version.bcpkix}",
+                            !org.bouncycastle.x509,
+                            !org.bouncycastle.util,
+                            !org.bouncycastle.pqc,
+                            !org.bouncycastle.ocsp,
+                            !org.bouncycastle.math,
+                            !org.bouncycastle.jce,
+                            !org.bouncycastle.jcajce,
+                            !org.bouncycastle.i18n,
+                            !org.bouncycastle.crypto,
+                            !org.bouncycastle.asn1
+                        </_exportcontents>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <exp.pkg.version.bcpkix>1.80.0.wso2v1</exp.pkg.version.bcpkix>
+        <imp.pkg.version.range.bcprov>[1.80.0, 2.0.0)</imp.pkg.version.range.bcprov>
+        <version.bc>1.80</version.bc>
+    </properties>
+
+</project>

--- a/bcprov/1.80.0.wso2v1/pom.xml
+++ b/bcprov/1.80.0.wso2v1/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+    <artifactId>bcprov-jdk18on</artifactId>
+    <packaging>bundle</packaging>
+    <name>bcprov</name>
+    <version>1.80.0.wso2v1</version>
+    <description>
+        This bundle will represent bouncycastle 1.80
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${version.bcprov}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bcprov-jdk18on
+            library as a transitive dependency. This is required because we are embedding bcprov-jdk18on library inside
+            this orbit bundle without extracting the content, because bcprov-jdk18on library is signed. If you embed a
+            dependency and set optional to true, then dependent projects will not be alble to compile their source with
+            this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Import-Package>
+                            !org.bouncycastle.*
+                        </Import-Package>
+                        <Export-Package>
+                            org.bouncycastle.*;version="${exp.pkg.version.bcprov}"
+                        </Export-Package>
+                        <Embed-Dependency>bcprov-jdk18on;scope=compile|runtime;inline=false</Embed-Dependency>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <exp.pkg.version.bcprov>1.80.0.wso2v1</exp.pkg.version.bcprov>
+        <version.bcprov>1.80</version.bcprov>
+    </properties>
+</project>

--- a/bctls/1.80.0.wso2v1/pom.xml
+++ b/bctls/1.80.0.wso2v1/pom.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+    <artifactId>bctls-jdk18on</artifactId>
+    <packaging>bundle</packaging>
+    <name>bctls</name>
+    <version>1.80.0.wso2v1</version>
+    <description>
+        This bundle will represent bouncycastle TLS 1.80
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 Internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bctls-jdk18on</artifactId>
+            <version>${version.bctls}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bctls-jdk18on
+            library as a transitive dependency. This is required because we are embedding bctls-jdk18on library inside
+            this orbit bundle without extracting the content, because bctls-jdk18on library is signed. If you embed a
+            dependency and set optional to true, then dependent projects will not be alble to compile their source with
+            this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
+            <version>${version.bc}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bcutil-jdk18on
+            library as a transitive dependency. This is required because we are embedding bcutil-jdk18on library inside
+            this orbit bundle without extracting the content, because bcutil-jdk18on library is signed. If you embed a
+            dependency and set optional to true, then dependent projects will not be alble to compile their source with
+            this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${version.bc}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bcprov-jdk18on
+            library as a transitive dependency. This is required because we are embedding bcprov-jdk18on library inside
+            this orbit bundle without extracting the content, because bcprov-jdk18on library is signed. If you embed a
+            dependency and set optional to true, then dependent projects will not be alble to compile their source with
+            this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${version.bc}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bcpkix-jdk18on
+            library as a transitive dependency. This is required because we are embedding bcpkix-jdk18on library inside
+            this orbit bundle without extracting the content, because bcpkix-jdk18on library is signed. If you embed a
+            dependency and set optional to true, then dependent projects will not be alble to compile their source with
+            this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Import-Package>
+                            org.bouncycastle.asn1;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.bsi;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.cms;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.eac;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.edec;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.nist;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.ocsp;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.oiw;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.pkcs;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.rosstandart;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.x500;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.x500.style;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.x509;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.x9;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.agreement;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.agreement.srp;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.digests;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.ec;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.encodings;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.engines;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.generators;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.io;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.macs;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.modes;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.params;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.prng;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.signers;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.tls;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.util;version="${imp.pkg.version.range}",
+                            org.bouncycastle.jcajce.interfaces;version="${imp.pkg.version.range}",
+                            org.bouncycastle.jcajce.io;version="${imp.pkg.version.range}",
+                            org.bouncycastle.jcajce.spec;version="${imp.pkg.version.range}",
+                            org.bouncycastle.jcajce.util;version="${imp.pkg.version.range}",
+                            org.bouncycastle.jce.interfaces;version="${imp.pkg.version.range}",
+                            org.bouncycastle.jce.provider;version="${imp.pkg.version.range}",
+                            org.bouncycastle.math.ec;version="${imp.pkg.version.range}",
+                            org.bouncycastle.math.ec.rfc7748;version="${imp.pkg.version.range}",
+                            org.bouncycastle.pqc.crypto.mlkem;version="${imp.pkg.version.range}",
+                            org.bouncycastle.util;version="${imp.pkg.version.range}",
+                            org.bouncycastle.util.encoders;version="${imp.pkg.version.range}",
+                            org.bouncycastle.util.io;version="${imp.pkg.version.range}"
+                        </Import-Package>
+                        <Export-Package>
+                            org.bouncycastle.jsse;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.jsse.java.security;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.jsse.provider;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.jsse.util;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto.impl;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto.impl.bc;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto.impl.jcajce;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto.impl.jcajce.srp;version="${exp.pkg.version.bctls}"
+                        </Export-Package>
+                        <Embed-Dependency>
+                            bctls-jdk18on;scope=compile|runtime;inline=false,
+                            bcutil-jdk18on;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <exp.pkg.version.bctls>1.80.0.wso2v1</exp.pkg.version.bctls>
+        <imp.pkg.version.range>[1.80.0, 2.0.0)</imp.pkg.version.range>
+        <version.bc>1.80</version.bc>
+        <version.bctls>1.80-wso2v1</version.bctls>
+    </properties>
+</project>

--- a/bcutil/1.80.0.wso2v1/pom.xml
+++ b/bcutil/1.80.0.wso2v1/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+    <artifactId>bcutil-jdk18on</artifactId>
+    <packaging>bundle</packaging>
+    <name>bcutil</name>
+    <version>1.80.0.wso2v1</version>
+    <description>
+        This bundle will represent bouncycastle util 1.80
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
+            <version>${version.bcutil}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bcutil-jdk18on
+            library as a transitive dependency. This is required because we are embedding bcutil-jdk18on library inside
+            this orbit bundle without extracting the content, because bcutil-jdk18on library is signed. If you embed a
+            dependency and set optional to true, then dependent projects will not be alble to compile their source with
+            this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Import-Package>
+                            org.bouncycastle.asn1;version="${imp.pkg.version.range.bcutil}",
+                            org.bouncycastle.asn1.nist;version="${imp.pkg.version.range.bcutil}",
+                            org.bouncycastle.asn1.ocsp;version="${imp.pkg.version.range.bcutil}",
+                            org.bouncycastle.asn1.pkcs;version="${imp.pkg.version.range.bcutil}",
+                            org.bouncycastle.asn1.x500;version="${imp.pkg.version.range.bcutil}",
+                            org.bouncycastle.asn1.x509;version="${imp.pkg.version.range.bcutil}",
+                            org.bouncycastle.math.ec;version="${imp.pkg.version.range.bcutil}",
+                            org.bouncycastle.util;version="${imp.pkg.version.range.bcutil}",
+                            org.bouncycastle.util.encoders;version="${imp.pkg.version.range.bcutil}",
+                            org.bouncycastle.util.io;version="${imp.pkg.version.range.bcutil}"
+                        </Import-Package>
+                        <Export-Package>
+                            org.bouncycastle.*;version="${exp.pkg.version.bcutil}"
+                        </Export-Package>
+                        <Embed-Dependency>bcutil-jdk18on;scope=compile|runtime;inline=false</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <exp.pkg.version.bcutil>1.80.0.wso2v1</exp.pkg.version.bcutil>
+        <imp.pkg.version.range.bcutil>[1.80.0, 2.0.0)</imp.pkg.version.range.bcutil>
+        <version.bcutil>1.80</version.bcutil>
+    </properties>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,12 @@
         <module>bcpkix/1.60.0.wso2v1</module>
         <module>bcpkix/1.70.0.wso2v1</module>
         <module>bcpkix/1.77.0.wso2v1</module>
+        <module>bcpkix/1.80.0.wso2v1</module>
         <module>bcprov/1.70.0.wso2v1</module>
         <module>bcprov/1.74.0.wso2v1</module>
         <module>bcprov/1.77.0.wso2v1</module>
+        <module>bcprov/1.80.0.wso2v1</module>
+        <module>bcutil/1.80.0.wso2v1</module>
         <module>jaxws-ri/2.3.2.wso2v1</module>
         <module>jta/1.1.0.wso2v1</module>
         <module>jta/1.1.0.wso2v2</module>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <module>bcprov/1.74.0.wso2v1</module>
         <module>bcprov/1.77.0.wso2v1</module>
         <module>bcprov/1.80.0.wso2v1</module>
+        <module>bctls/1.80.0.wso2v1</module>
         <module>bcutil/1.80.0.wso2v1</module>
         <module>jaxws-ri/2.3.2.wso2v1</module>
         <module>jta/1.1.0.wso2v1</module>


### PR DESCRIPTION
## Purpose
<!--
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
-->
- Add BouncyCastle `prov`, `pkix`, and `util` libraries of version 1.80.
- Add BouncyCastle `tls` library of version 1.80 using WSO2 fork containing custom modifications.