### PR TITLE
Add pom.xml for Apache Zookeeper 3.9.3.wso2v1 bundle

### DIFF
--- a/zookeeper/3.9.3.wso2v1/pom.xml
+++ b/zookeeper/3.9.3.wso2v1/pom.xml
@@ -1,0 +1,104 @@
+<!--
+ ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.zookeeper.wso2</groupId>
+    <artifactId>apache-zookeeper</artifactId>
+    <packaging>bundle</packaging>
+    <name>zookeeper.wso2</name>
+    <version>${orbit.zookeeper.version}</version>
+    <description>
+        This bundle will represent org.apache.zookeeper
+    </description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Vendor>WSO2, Inc.</Bundle-Vendor>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>org.apache.jute.*</Private-Package>
+                        <Import-Package/>
+                        <Export-Package>
+                            org.apache.zookeeper.*;-split-package:=merge-first
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <!-- Orbit patched version -->
+        <orbit.zookeeper.version>3.9.3.wso2v1</orbit.zookeeper.version>
+        <!-- Patched zookeeper version -->
+        <zookeeper.version>3.9.3</zookeeper.version>
+        <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose

- Address CVE-2024-51504
- For the fix of https://github.com/wso2-enterprise/wso2-apim-internal/issues/10016

## Approach

Bumped `zookeeper` to version 3.9.3.wso2v1, updating `zookeeper` dependency to version 3.9.3.