### PR TITLE
[Bundle][Bump] uap-java in ua-parser from 1.5.4.wso2v2 to 1.6.1.wso2v2

### DIFF
--- a/ua-parser/1.6.1.wso2v2/pom.xml
+++ b/ua-parser/1.6.1.wso2v2/pom.xml
@@ -26,7 +26,7 @@
     <name>ua-parser-wso2</name>
     <version>1.6.1.wso2v1</version>
     <description>
-        This bundle represents ua-parser 1.6.1 and the default snakeyaml version 2.2.0
+        This bundle represents ua-parser 1.6.1 and the default snakeyaml version 2.0.
     </description>
     <url>http://wso2.org</url>
 
@@ -94,7 +94,7 @@
 
     <properties>
         <ua-parser.version>1.6.1</ua-parser.version>
-        <snake-yaml.version>2.2</snake-yaml.version>
+        <snake-yaml.version>2.0</snake-yaml.version>
     </properties>
 
 </project>


### PR DESCRIPTION
Bump com.github.ua-parser:uap-java to 1.6.1 [[1]](https://mvnrepository.com/artifact/com.github.ua-parser/uap-java/1.6.1) from 1.5.4 
Bundle from 1.5.4.wso2v2 [[2]](https://github.com/wso2/orbit/tree/master/ua-parser/1.5.4.wso2v2) to 1.6.1.wso2v2
In order to support detection for Edge Chromium [[3]](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance#user-agent-strings)[[4]](https://github.com/ua-parser/uap-core/issues/443).

[1] https://mvnrepository.com/artifact/com.github.ua-parser/uap-java/1.6.1
[2] https://github.com/wso2/orbit/tree/master/ua-parser/1.5.4.wso2v2
[3] https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance#user-agent-strings
[4] https://github.com/ua-parser/uap-core/issues/443

### Related PRs
  - https://github.com/wso2/orbit/pull/1231

## Related Issue
public issue: https://github.com/wso2/product-is/issues/24434