### PR TITLE
[Bundle][Bump] uap-java in ua-parser from 1.5.4.wso2v2 to 1.6.1.wso2v2 - Correcting the version

### DIFF
--- a/ua-parser/1.6.1.wso2v2/pom.xml
+++ b/ua-parser/1.6.1.wso2v2/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>ua-parser</artifactId>
     <packaging>bundle</packaging>
     <name>ua-parser-wso2</name>
-    <version>1.6.1.wso2v1</version>
+    <version>1.6.1.wso2v2</version>
     <description>
         This bundle represents ua-parser 1.6.1 and the default snakeyaml version 2.0.
     </description>


### PR DESCRIPTION
Correction of `wso2v` version from **1.6.1.wso2v1** to **1.6.1.wso2v2** related to [[1]](https://github.com/wso2/orbit/pull/1229)

### Related PRs
  - [1] https://github.com/wso2/orbit/pull/1229