### PR TITLE
Exclude commons-lang from ESAPI in Opensaml Orbit Bundles 2.6.6.wso2v9 and 3.3.1.wso2v15

### DIFF
--- a/opensaml/2.6.6.wso2v9/pom.xml
+++ b/opensaml/2.6.6.wso2v9/pom.xml
@@ -198,6 +198,10 @@
                     <artifactId>commons-collections</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>

--- a/opensaml/3.3.1.wso2v15/pom.xml
+++ b/opensaml/3.3.1.wso2v15/pom.xml
@@ -871,6 +871,10 @@
                     <artifactId>commons-configuration</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>commons-beanutils</groupId>
                     <artifactId>commons-beanutils-core</artifactId>
                 </exclusion>


### PR DESCRIPTION
In the Orbit bundles opensaml:2.6.6.wso2v9 and opensaml:3.3.1.wso2v15, we upgraded esapi to version 2.7.0.0, which is the latest available version. However, this version includes transitive dependencies that have known vulnerabilities — specifically from commons-configuration and commons-lang.

We have already excluded commons-configuration in a previous update. With this PR, we are now excluding the vulnerable commons-lang dependency as well.