### PR TITLE
Add tomcat and Json orbits

### DIFF
--- a/tomcat/9.0.108.wso2v1/pom.xml
+++ b/tomcat/9.0.108.wso2v1/pom.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 LLC. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.apache.tomcat</groupId>
+    <artifactId>tomcat</artifactId>
+    <version>9.0.108.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>tomcat orbit bundle - 9.0.108.wso2v1</name>
+    <description>Apache Tomcat</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-dbcp</artifactId>
+            <version>${version.tomcat}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${version.tomcat}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <version>${version.tomcat}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-websocket-api</artifactId>
+            <version>${version.tomcat}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <version>${version.tomcat}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper</artifactId>
+            <version>${version.tomcat}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jaspic-api</artifactId>
+            <version>${version.tomcat}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper-el</artifactId>
+            <version>${version.tomcat}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jdt.core.compiler</groupId>
+            <artifactId>ecj</artifactId>
+            <version>${version.ecj}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <version>2.4.0</version>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            !org.apache.tomcat.jdbc.pool.*,
+                            !org.apache.juli.logging,
+                            org.apache.jasper.*;version="2.2.2";-split-package:=merge-first,
+                            org.apache.naming.*;version="${version.tomcat}",
+                            org.apache.tomcat.*;version="${version.tomcat}";-split-package:=merge-first,
+                            org.apache.catalina.*;version="${version.tomcat}",
+                            org.apache.coyote.*;version="${version.tomcat}",
+                            org.apache.el.*;version="${version.tomcat}";-split-package:=merge-first,
+                            javax.websocket.*;version="1.1.0";-split-package:=merge-first,
+                            javax.security.auth.message.*;version="6.0.0";-split-package:=merge-first
+                        </Export-Package>
+                        <Private-Package>
+                            org.apache.juli
+                        </Private-Package>
+                        <Import-Package>
+                            javax.annotation;version="0.0.0",
+                            *;resolution:=optional
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                        <Include-Resource>
+                            {maven-resources},
+                            @tomcat-embed-websocket-${version.tomcat}.jar!/META-INF/*,
+                            src/main/resources
+                        </Include-Resource>
+                        <Bundle-Classpath>patch.jar,.</Bundle-Classpath>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <version.tomcat>9.0.108</version.tomcat>
+        <version.ecj>4.6.1</version.ecj>
+    </properties>
+</project>

--- a/tomcat/9.0.108.wso2v1/src/main/resources/META-INF/services/javax.el.ExpressionFactory
+++ b/tomcat/9.0.108.wso2v1/src/main/resources/META-INF/services/javax.el.ExpressionFactory
@@ -1,0 +1,1 @@
+org.apache.el.ExpressionFactoryImpl


### PR DESCRIPTION
This pull request introduces a new Maven module for the Tomcat 9.0.108.wso2v1 Orbit bundle, including its project configuration and required service provider file. The changes set up the module for OSGi packaging, dependency management, and proper service loading.

**New Tomcat Orbit Bundle Module:**

* Added a new `pom.xml` in `tomcat/9.0.108.wso2v1` to define the Maven project for the Tomcat 9.0.108.wso2v1 Orbit bundle, including dependencies on Tomcat components, OSGi bundle configuration, and repository settings.
* Created the `META-INF/services/javax.el.ExpressionFactory` file to register `org.apache.el.ExpressionFactoryImpl` as the EL ExpressionFactory implementation for Java's Service Provider Interface (SPI) discovery.