### PR TITLE
Fix Jaeger/Zipkin tracing orbit bundles

### DIFF
--- a/jaeger-client-jdk21/1.8.0.wso2v2/pom.xml
+++ b/jaeger-client-jdk21/1.8.0.wso2v2/pom.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 LLC. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.io.jaeger</groupId>
+    <artifactId>jaeger-client-jdk21</artifactId>
+    <version>${jaeger-client.orbit.version}</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Jaeger Client</name>
+    <description>
+        This bundle represents Jaeger Client. This is used with JDK 21+.
+    </description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <!-- Jaeger Dependencies -->
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-client</artifactId>
+            <version>${jaeger.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-core</artifactId>
+            <version>${jaeger.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-thrift</artifactId>
+            <version>${jaeger.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-tracerresolver</artifactId>
+            <version>${jaeger.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- OpenTracing Dependencies -->
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-tracerresolver</artifactId>
+            <version>${opentracing.tracerresolver.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>${opentracing.api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.brave</groupId>
+            <artifactId>brave-opentracing</artifactId>
+            <version>${brave.opentracing.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>span-reporter</artifactId>
+            <version>${span.reporter.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <!-- Other Dependencies -->
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>${libthrift.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+        </repository>
+    </repositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${felix.bundle.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.jaegertracing.*; version="${jaeger-client.orbit.version}",
+                            io.opentracing.*; version="${jaeger-client.orbit.version}",
+                            io.opentracing.contrib.*; version="${jaeger-client.orbit.version}",
+                            brave.*; version="${jaeger-client.orbit.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            com.google.gson; version="${com.google.gson.version.range}",
+                            com.google.gson.reflect; version="${com.google.gson.version.range}",
+                            javax.annotation; version="${javax.annotation.version.range}",
+                            javax.net; version="${default.import.version}",
+                            javax.net.ssl; version="${default.import.version}",
+                            javax.security.auth.callback; version="${default.import.version}",
+                            javax.security.sasl; version="${default.import.version}",
+                            javax.servlet; version="${javax.servlet.version.range}",
+                            javax.servlet.http; version="${javax.servlet.version.range}",
+                            org.apache.http; version="${org.apache.http.version.range}",
+                            org.apache.http.client; version="${org.apache.http.client.version.range}",
+                            org.apache.http.client.methods; version="${org.apache.http.client.version.range}",
+                            org.apache.http.entity; version="${org.apache.http.version.range}",
+                            org.apache.http.params; version="${org.apache.http.version.range}",
+                            org.slf4j; version="${org.slf4j.version.range}",
+                            zipkin2.reporter; version="${zipkin.reporter.import.version.range}",
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>*;scope=compile|runtime;inline=true;</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <jaeger-client.orbit.version>1.8.0.wso2v2</jaeger-client.orbit.version>
+        <jaeger.version>1.8.0</jaeger.version>
+        <opentracing.tracerresolver.version>0.1.8</opentracing.tracerresolver.version>
+        <opentracing.api.version>0.32.0</opentracing.api.version>
+        <libthrift.version>0.16.0</libthrift.version>
+        <felix.bundle.plugin.version>2.3.7</felix.bundle.plugin.version>
+
+        <!-- Import Versions -->
+        <com.google.gson.version.range>[2.8.0,3)</com.google.gson.version.range>
+        <default.import.version>[0.0.0,1.0.0)</default.import.version>
+        <javax.annotation.version.range>[1.0.0,2.0.0)</javax.annotation.version.range>
+        <javax.servlet.version.range>[3.1.0, 4.0.0)</javax.servlet.version.range>
+        <org.apache.http.version.range>[4.3.3,5.0.0)</org.apache.http.version.range>
+        <org.apache.http.client.version.range>[4.3.6,5.0.0)</org.apache.http.client.version.range>
+        <org.slf4j.version.range>[1.7.0,1.8.0)</org.slf4j.version.range>
+        <brave.opentracing.version>0.32.0</brave.opentracing.version>
+        <span.reporter.version>0.1.0</span.reporter.version>
+        <zipkin.reporter.import.version.range>[2.7,4.0.0)</zipkin.reporter.import.version.range>
+    </properties>
+</project>

--- a/zipkin-sender-okhttp3/3.5.1.wso2v2/pom.xml
+++ b/zipkin-sender-okhttp3/3.5.1.wso2v2/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.io.zipkin.reporter2</groupId>
+    <artifactId>zipkin-sender-okhttp3</artifactId>
+    <version>3.5.1.wso2v2</version>
+    <packaging>bundle</packaging>
+    <name>zipkin-sender-okhttp3.wso2</name>
+    <description>
+        This bundle exports io.zipkin.reporter2.zipkin-sender-okhttp3
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-sender-okhttp3</artifactId>
+            <version>${zipkin-reporter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-reporter</artifactId>
+            <version>${zipkin-reporter.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Vendor>WSO2 LLC.</Bundle-Vendor>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                        </Private-Package>
+                        <Export-Package>
+                            zipkin2.reporter;version="${zipkin-reporter.version}",
+                            zipkin2.reporter.okhttp3;uses:="okhttp3,zipkin2,zipkin2.codec,zipkin2.reporter";version="${zipkin-reporter.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            okhttp3;version="[3.11,5)",
+                            okio;version="[1.15,4)",
+                            zipkin2;version="[2.27,3)",
+                            zipkin2.codec;version="[2.27,3)",
+                            !zipkin2.reporter.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>*;scope=compile|runtime;inline=true;</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <zipkin-reporter.version>3.5.1</zipkin-reporter.version>
+        <okhttp.version>4.11.0</okhttp.version>
+        <okio.version>3.5.0</okio.version>
+    </properties>
+</project>


### PR DESCRIPTION
## Problem
APIM gateway startup fails due to OSGi wiring issues for Zipkin reporter packages (zipkin2.reporter.Reporter / zipkin2.reporter.BytesEncoder) when used via Jaeger/Brave and OpenTelemetry exporters.

## Changes
Jaeger orbit: widen zipkin2.reporter import range and bump orbit version to 1.8.0.wso2v2.
Zipkin sender orbit: embed/export zipkin2.reporter and bump orbit version to 3.5.1.wso2v2 so dependent OTEL exporters can resolve reporter classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Jaeger distributed tracing framework (JDK21 compatible) with full OpenTracing integration
  * Added support for Zipkin distributed tracing with OkHttp3 sender capability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->