### PR TITLE
Add bctls 1.84.0.wso2v1 orbit bundle

### DIFF
--- a/bctls/1.84.0.wso2v1/pom.xml
+++ b/bctls/1.84.0.wso2v1/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+    <artifactId>bctls-jdk18on</artifactId>
+    <packaging>bundle</packaging>
+    <name>bctls</name>
+    <version>1.84.0.wso2v1</version>
+    <description>
+        This bundle will represent bouncycastle TLS 1.84
+    </description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bctls-jdk18on</artifactId>
+            <version>${version.bc}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bcutil-jdk18on
+            library as a transitive dependency. This is required because we are embedding bcutil-jdk18on library inside
+            this orbit bundle without extracting the content, because bcutil-jdk18on library is signed. If you embed a
+            dependency and set optional to true, then dependent projects will not be able to compile their source with
+            this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
+            <version>${version.bc}</version>
+            <!-- By setting optional false, dependent projects of this orbit bundle will be able to see bcutil-jdk18on
+             library as a transitive dependency. This is required because we are embedding bcutil-jdk18on library inside
+             this orbit bundle without extracting the content, because bcutil-jdk18on library is signed. If you embed a
+             dependency and set optional to true, then dependent projects will not be able to compile their source
+             with this orbit bundle.-->
+            <optional>false</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Import-Package>
+                            org.bouncycastle.util*;version="${imp.pkg.version.range}",
+                            org.bouncycastle.pqc.*;version="${imp.pkg.version.range}",
+                            org.bouncycastle.math.*;version="${imp.pkg.version.range}",
+                            org.bouncycastle.jce.*;version="${imp.pkg.version.range}",
+                            org.bouncycastle.jcajce.*;version="${imp.pkg.version.range}",
+                            org.bouncycastle.asn1.*;version="${imp.pkg.version.range}",
+                            org.bouncycastle.crypto.*;version="${imp.pkg.version.range}",
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Export-Package>
+                            org.bouncycastle.jsse;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.jsse.java.security;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.jsse.provider;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.jsse.util;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto.impl;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto.impl.bc;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto.impl.jcajce;version="${exp.pkg.version.bctls}",
+                            org.bouncycastle.tls.crypto.impl.jcajce.srp;version="${exp.pkg.version.bctls}",
+                            !org.bouncycastle.util,
+                            !org.bouncycastle.pqc,
+                            !org.bouncycastle.math,
+                            !org.bouncycastle.jce,
+                            !org.bouncycastle.jcajce,
+                            !org.bouncycastle.crypto,
+                            !org.bouncycastle.asn1
+                        </Export-Package>
+                        <Embed-Dependency>
+                            bctls-jdk18on;scope=compile|runtime;inline=false,
+                            bcutil-jdk18on;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <exp.pkg.version.bctls>1.84.0</exp.pkg.version.bctls>
+        <imp.pkg.version.range>[1.84.0, 2.0.0)</imp.pkg.version.range>
+        <version.bc>1.84</version.bc>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose
Add the orbit bundle for Bouncy Castle TLS 1.84.0.wso2v1 to align with the bcprov, bcpkix, and bcpg 1.84 bundles already present in the repository.

## Related Issue
N/A

## Implementation
Created `bctls/1.84.0.wso2v1/pom.xml` based on the existing `bctls/1.83.0.wso2v1` bundle, updating version references from 1.83 to 1.84. The bundle embeds `bctls-jdk18on` and `bcutil-jdk18on` at version 1.84 and exports the standard `org.bouncycastle.jsse.*` and `org.bouncycastle.tls.*` packages.