### PR TITLE
Add libthrift 0.23.0 OSGi bundle (wso2v1)

### DIFF
--- a/libthrift/0.23.0.wso2v1/pom.xml
+++ b/libthrift/0.23.0.wso2v1/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 LLC. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>libthrift.wso2</groupId>
+    <artifactId>libthrift</artifactId>
+    <version>0.23.0.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>libthrift.wso2</name>
+    <description>
+        This bundle will represent libthrift
+    </description>
+    <url>http://wso2.org</url>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>${thrift.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.apache.thrift.*;version="${thrift.osgi.version}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            !org.apache.thrift.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <thrift.osgi.version>0.23.0.wso2v1</thrift.osgi.version>
+        <thrift.version>0.23.0</thrift.version>
+    </properties>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,7 @@
         <module>solr/10.0.0.wso2v1</module>
         <module>webauthn4j/0.21.0.wso2v1</module>
         <module>libthrift/0.16.0.wso2v1</module>
+        <module>libthrift/0.23.0.wso2v1</module>
         <module>commons-net/3.9.0.wso2v1</module>
         <module>httpcore5/5.2.1.wso2v1</module>
         <module>httpclient5/5.2.1.wso2v1</module>


### PR DESCRIPTION
## Summary

- Adds a new WSO2 orbit bundle for **Apache Thrift 0.23.0** (`libthrift/0.23.0.wso2v1/pom.xml`)
- Registers the module in the root `pom.xml` alongside the existing `libthrift/0.16.0.wso2v1` entry
- Exports `org.apache.thrift.*;version="0.23.0.wso2v1"` via the Felix bundle plugin; all non-thrift imports marked `resolution:=optional`

## Test plan

- [ ] Build the bundle with `mvn clean install` inside `libthrift/0.23.0.wso2v1/` — expect a valid OSGi JAR
- [ ] Confirm `META-INF/MANIFEST.MF` inside the built JAR contains `Export-Package: org.apache.thrift.*;version=0.23.0.wso2v1`
- [ ] Publish to WSO2 Nexus snapshots and verify downstream consumers can resolve the artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)