### PR TITLE
Release aws-core - 2.30.22.wso2v3

### DIFF
--- a/aws-core/2.30.22.wso2v3/pom.xml
+++ b/aws-core/2.30.22.wso2v3/pom.xml
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 LLC. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
+    <artifactId>aws-core</artifactId>
+    <packaging>bundle</packaging>
+    <name>AWS-Core</name>
+    <version>${awscore.orbit.version}</version>
+    <description>A custom bundle that wraps aws-java-sdk-core/lambda/apigateway and other related dependencies</description>
+    <url>http://www.wso2.com</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>lambda</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apigateway</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-sdk-java</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apigatewayv2</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-json-protocol</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>identity-spi</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries-spi</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>endpoints-spi</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-spi</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>metrics-spi</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>protocol-core</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>third-party-jackson-core</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>checksums</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>checksums-spi</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>json-utils</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>${software.amazon.awssdk.crt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.eventstream</groupId>
+            <artifactId>eventstream</artifactId>
+            <version>${software.amazon.eventstream.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            software.amazon.awssdk.services.apigateway.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.core.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.auth.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.awscore.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.auth.credentials.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.http.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.regions.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.services.lambda.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.services.sts.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.retries.*; version="${awscore.orbit.version}",
+                            software.amazon.awssdk.crt.*; version="${software.amazon.awssdk.crt.version}",
+                            software.amazon.eventstream.*; version="${software.amazon.eventstream.version}"
+                        </Export-Package>
+                        <Embed-Dependency>
+                            aws-core;utils,scope=compile|runtime;inline=false,
+                            regions;scope=compile|runtime;inline=false,
+                            apache-client;scope=compile|runtime;inline=false,
+                            apigateway;scope=compile|runtime;inline=false,
+                            identity-spi;scope=compile|runtime;inline=false,
+                            retries-spi;scope=compile|runtime;inline=false,
+                            profiles;scope=compile|runtime;inline=false,
+                            endpoints-spi;scope=compile|runtime;inline=false,
+                            http-auth-spi;scope=compile|runtime;inline=false,
+                            auth;scope=compile|runtime;inline=false,
+                            http-auth-aws;scope=compile|runtime;inline=false,
+                            aws-json-protocol;scope=compile|runtime;inline=false,
+                            metrics-spi;scope=compile|runtime;inline=false,
+                            protocol-core;scope=compile|runtime;inline=false,
+                            json-utils;scope=compile|runtime;inline=false,
+                            third-party-jackson-core;scope=compile|runtime;inline=false,
+                            checksums;scope=compile|runtime;inline=false,
+                            checksums-spi;scope=compile|runtime;inline=false,
+                            http-auth;scope=compile|runtime;inline=false,
+                            lambda;scope=compile|runtime;inline=false,
+                            http-client-spi;scope=compile|runtime;inline=false,
+                            retries;scope=compile|runtime;inline=false,
+                            sdk-core;scope=compile|runtime;inline=false,
+                            sts;scope=compile|runtime;inline=false,
+                            aws-crt;scope=compile|runtime;inline=false,
+                            eventstream;scope=compile|runtime;inline=false
+                        </Embed-Dependency>
+                        <Import-Package>
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <software.amazon.awssdk.version>2.30.22</software.amazon.awssdk.version>
+        <software.amazon.awssdk.crt.version>0.29.22</software.amazon.awssdk.crt.version>
+        <software.amazon.eventstream.version>1.0.1</software.amazon.eventstream.version>
+        <awscore.orbit.version>2.30.22.wso2v3</awscore.orbit.version>
+    </properties>
+
+</project>


### PR DESCRIPTION
## Summary
Export AWS SDK retries packages to enable `StandardRetryStrategy` usage in dependent bundles.

## Changes
- **Version**: `2.30.22.wso2v2` → `2.30.22.wso2v3`
- **Added Export-Package**: `software.amazon.awssdk.retries.*`

The orbit bundle previously embedded retries packages but didn't export them for OSGi bundle wiring.