### PR TITLE
Add POM file for netty-all 4.2.13.wso2v1 bundle

### DIFF
--- a/netty/4.2.13.wso2v1/pom.xml
+++ b/netty/4.2.13.wso2v1/pom.xml
@@ -1,0 +1,80 @@
+<!--
+ ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.io.netty</groupId>
+    <artifactId>netty-all</artifactId>
+    <version>4.2.13.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Orbit - Netty (all)</name>
+    <description>This bundle will export packages from netty-all library of io.netty</description>
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            io.netty.*;version="${export.pkg.version.netty}"
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            io.netty.internal.tcnative;resolution:=optional,
+                            !io.netty.*,
+                            sun.nio.ch;resolution:=optional,
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <io.netty.version>4.2.13.Final</io.netty.version>
+        <export.pkg.version.netty>4.2.13.wso2v1</export.pkg.version.netty>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>


### PR DESCRIPTION
### Description
This pull request introduces a new Maven project configuration for the Netty library under the WSO2 Orbit project. The main change is the addition of a `pom.xml` file that defines how the Netty library is packaged and managed within the WSO2 ecosystem.

Key changes:

**New Maven project setup:**
* Added a new `pom.xml` in the `netty/4.2.13.wso2v1` directory to configure the Netty library (`netty-all`) as a bundle for WSO2, including project metadata, dependencies, build plugins, and export/import package instructions.