### PR TITLE
Add commons-configuration2 2.15.1.wso2v1 bundle

### DIFF
--- a/commons-configuration2/2.15.1.wso2v1/pom.xml
+++ b/commons-configuration2/2.15.1.wso2v1/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~ http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.apache.commons</groupId>
+    <artifactId>commons-configuration2</artifactId>
+    <version>2.15.1.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Orbit - Apache Commons Configuration2</name>
+    <description>
+        OSGi bundle wrapping Apache Commons Configuration2 with java.applet, commons-text,
+        and java.awt imports marked optional for server-side compatibility.
+    </description>
+
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>${commons.configuration2.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons.text.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.9</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.apache.commons.configuration2.*;version="${commons.configuration2.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.apache.commons.text.lookup;version="[1.0,2.0)",
+                            java.applet;resolution:=optional,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>commons-configuration2;inline=true</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <commons.configuration2.version>2.15.1</commons.configuration2.version>
+        <commons.text.version>1.12.0</commons.text.version>
+    </properties>
+</project>


### PR DESCRIPTION
### Description
This PR introduces a new WSO2 Orbit bundle wrapping `commons-configuration2` version `2.15.1`. This wrapper addresses critical OSGi framework wiring failures and runtime `NoClassDefFoundError` issues observed during a dependency upgrade within the Micro Integrator (MI) 4.5.0 environment.

### Technical Root Cause
1. **OSGi Block on Startup (`java.applet`):** Upstream version `2.15.1` of `commons-configuration2` automatically generates a strict mandatory `Import-Package` statement for `java.applet` in its standard manifest. Because `java.applet` is missing or unexported by the runtime JVM/system bundle baseline (especially on modern JDKs), dependent platform bundles such as `org.wso2.micro.integrator.management.apis` fail to resolve and crash during initialization.
2. **Runtime Class Resolution Failure (`commons-text`):** Downstream code in `commons-configuration2` utilizes string interpolation features (`DefaultLookups`) that transitively rely on `org.apache.commons.text.lookup.StringLookupFactory`. A blanket dynamic fallback (`*;resolution:=optional`) shifts the failure from boot-time to run-time, triggering an unhandled `java.lang.NoClassDefFoundError` inside `LoggingResource.loadConfigs`.