### PR TITLE
Add new orbit bundle for Solace Messaging API For Java(JCSMP)

### DIFF
--- a/solace-jcsmp/10.30.0.wso2v1/pom.xml
+++ b/solace-jcsmp/10.30.0.wso2v1/pom.xml
@@ -1,0 +1,209 @@
+<!--
+ ~ Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.solacesystems</groupId>
+    <artifactId>sol-jcsmp</artifactId>
+    <packaging>jar</packaging>
+    <name>WSO2 Carbon Orbit - Solace JCSMP java client</name>
+    <version>10.30.0.wso2v1</version>
+    <description>
+        This JAR will bundle the packages from sol-jcsmp-10.30.0.jar together with the necessary io.netty
+        dependencies.
+    </description>
+    <url>http://wso2.org</url>
+    <properties>
+        <solace.jcsmp.version>10.30.0</solace.jcsmp.version>
+        <io.netty.version>4.2.12.Final</io.netty.version>
+        <jzlib.version>1.1.3_2</jzlib.version>
+        <maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+    </properties>
+
+    <dependencies>
+        <!-- Solace JCSMP Java Client. -->
+        <dependency>
+            <groupId>com.solacesystems</groupId>
+            <artifactId>sol-jcsmp</artifactId>
+            <version>${solace.jcsmp.version}</version>
+        </dependency>
+
+        <!-- io.netty modules used by the Solace Netty transport. Declared explicitly (and pinned
+             to ${io.netty.version}) so the bundled/relocated set is self-documenting; these are
+             also resolved transitively via sol-jcsmp. -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-classes-epoll</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${io.netty.version}</version>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-base</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-compression</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-socks</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <version>${io.netty.version}</version>
+        </dependency>
+
+        <!-- Compression library required by sol-jcsmp (bundled un-relocated). -->
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.jzlib</artifactId>
+            <version>${jzlib.version}</version>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <outputFile>${project.build.directory}/${project.build.finalName}.jar</outputFile>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.solacesystems:sol-jcsmp</include>
+                                    <include>io.netty:netty-common</include>
+                                    <include>io.netty:netty-buffer</include>
+                                    <include>io.netty:netty-resolver</include>
+                                    <include>io.netty:netty-transport</include>
+                                    <include>io.netty:netty-transport-native-unix-common</include>
+                                    <include>io.netty:netty-transport-classes-epoll</include>
+                                    <include>io.netty:netty-transport-native-epoll</include>
+                                    <include>io.netty:netty-codec-base</include>
+                                    <include>io.netty:netty-codec-compression</include>
+                                    <include>io.netty:netty-codec-http</include>
+                                    <include>io.netty:netty-codec-socks</include>
+                                    <include>io.netty:netty-handler</include>
+                                    <include>io.netty:netty-handler-proxy</include>
+                                    <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.jzlib</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>io.netty.wso2.orbit.shaded</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
## Purpose
> Adds a new orbit module (org.wso2.orbit.com.solacesystems:sol-jcsmp:10.30.0.wso2v1) that bundles the Solace JCSMP client with its Netty 4.2.12 dependencies and jzlib, relocating io.netty → io.netty.wso2.orbit.shaded.

### Reason

> This mirrors the existing rabbit-mq-amqp-1.0 orbit. It's needed because sol-jcsmp's Netty-based transport registers a global AttributeKey (TOTAL_SOCKET_BYTES_SENT) via newInstance, which throws 'TOTAL_SOCKET_BYTES_SENT' is already in use when raw sol-jcsmp binds to the server's shared netty-all pool and a second consumer (connector + inbound together, or a hot-redeploy) initializes the transport; relocating Netty gives each consumer a private pool and eliminates the collision. Built with maven-shade-plugin (explicit artifactSet for all 13 Netty modules, ServicesResourceTransformer, signature-file filtering, createDependencyReducedPom=false) as a standalone module matching the rabbit-mq-amqp-1.0 precedent; verified that the output jar has 2382 Netty classes relocated under io/netty/wso2/orbit/shaded/, zero un-relocated io.netty classes, and NettySolTransport referencing the relocated AttributeKey.

