### PR TITLE
Resolve runtime OOM loop in JSTL orbit bundle by refining import rules

### DIFF
--- a/jstl/1.2.1.wso2v5/pom.xml
+++ b/jstl/1.2.1.wso2v5/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~ http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.javax.servlet.jsp.jstl</groupId>
+    <artifactId>jstl</artifactId>
+    <version>1.2.1.wso2v5</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Javax servlet bundle</name>
+    <description>Javax Servlet API</description>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.servlet.jsp.jstl</artifactId>
+            <version>${version.jstl.glassfish}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet.jsp.jstl</groupId>
+            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+            <version>${version.jstl}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package></Private-Package>
+                        <Export-Package>
+                            org.apache.taglibs.standard.*;version="${exp.pkg.version.org.apache.taglibs.standard}";-split-package:=merge-first,
+                            javax.servlet.jsp.jstl.*;version="${exp.pkg.version.javax.servlet.jsp.jstl}";-split-package:=merge-first
+                        </Export-Package>
+                        <Import-Package>
+                            javax.el;resolution:=optional,
+                            javax.servlet;resolution:=optional,
+                            javax.servlet.http;resolution:=optional,
+                            javax.servlet.jsp;resolution:=optional,
+                            javax.servlet.jsp.tagext;resolution:=optional,
+                            javax.xml.parsers;resolution:=optional,
+                            org.xml.sax;resolution:=optional,
+                            org.xml.sax.helpers;resolution:=optional,
+                            javax.xml.transform.*;resolution:=optional,
+                            javax.xml.xpath;resolution:=optional,
+                            org.w3c.dom;resolution:=optional,
+                            !javax.servlet.jsp.jstl.*,
+                            !org.apache.taglibs.standard.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <version.jstl>1.2.1</version.jstl>
+        <version.jstl.glassfish>1.2.5</version.jstl.glassfish>
+        <orbit.version.jstl>1.2.1.wso2v5</orbit.version.jstl>
+        <exp.pkg.version.javax.servlet.jsp.jstl>1.2.1</exp.pkg.version.javax.servlet.jsp.jstl>
+        <exp.pkg.version.org.apache.taglibs.standard>1.2.5</exp.pkg.version.org.apache.taglibs.standard>
+        <imp.pkg.version.javax.servlet.jsp.jstl>[1.2.1, 1.3.0)</imp.pkg.version.javax.servlet.jsp.jstl>
+    </properties>
+</project>


### PR DESCRIPTION
## Purpose
Replaced the open-ended dynamic imports and added explicit package exclusions to eliminate the combinatorial graph explosion inside CandidateSelector during EI server boot.