### PR TITLE
Change import package details

### DIFF
--- a/commons-configuration2/2.15.1.wso2v2/pom.xml
+++ b/commons-configuration2/2.15.1.wso2v2/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~ http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.org.apache.commons</groupId>
+    <artifactId>commons-configuration2</artifactId>
+    <version>2.15.1.wso2v2</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Orbit - Apache Commons Configuration2</name>
+    <description>
+        OSGi bundle wrapping Apache Commons Configuration2 with commons-io, commons-text, commons.logging
+        and commons-lang3 imports marked optional for server-side compatibility.
+    </description>
+
+    <url>http://wso2.org</url>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>${commons.configuration2.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons.text.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.9</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.apache.commons.configuration2.*;version="${commons.configuration2.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            !org.apache.commons.configuration2.*,
+                            org.apache.commons.text.lookup;version="[1.0,2.0)";resolution:=optional,
+                            org.apache.commons.lang3.*;version="[3.0,4.0)";resolution:=optional,
+                            org.apache.commons.io.*;version="[2.0,3.0)";resolution:=optional,
+                            org.apache.commons.logging.*;version="[1.1,2.0)";resolution:=optional,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <commons.configuration2.version>2.15.1</commons.configuration2.version>
+        <commons.text.version>1.12.0</commons.text.version>
+    </properties>
+</project>

--- a/commons-configuration2/2.15.1.wso2v2/pom.xml
+++ b/commons-configuration2/2.15.1.wso2v2/pom.xml
@@ -53,12 +53,6 @@
             <version>${commons.configuration2.version}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>${commons.text.version}</version>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
     <build>
@@ -77,7 +71,7 @@
                         </Export-Package>
                         <Import-Package>
                             !org.apache.commons.configuration2.*,
-                            org.apache.commons.text.lookup;version="[1.0,2.0)";resolution:=optional,
+                            org.apache.commons.text.*;version="[1.0,2.0)",
                             org.apache.commons.lang3.*;version="[3.0,4.0)";resolution:=optional,
                             org.apache.commons.io.*;version="[2.0,3.0)";resolution:=optional,
                             org.apache.commons.logging.*;version="[1.1,2.0)";resolution:=optional,
@@ -93,6 +87,5 @@
 
     <properties>
         <commons.configuration2.version>2.15.1</commons.configuration2.version>
-        <commons.text.version>1.12.0</commons.text.version>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
Only with *;resolution:=optional, the org.apache.commons.io.build package is not getting wired properly. Even though wso2mi does not have any use cases in commons-configuration2 with that package, there can be custom implementations developed by the customers. Hence, changing the import package details.