### PR TITLE
Fix jackson-annotations version in solr 9.10.1.wso2v2

### DIFF
--- a/solr/9.10.1.wso2v2/pom.xml
+++ b/solr/9.10.1.wso2v2/pom.xml
@@ -411,7 +411,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.annotations.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -570,6 +570,7 @@
         <version.hadoop>3.4.1</version.hadoop>
         <version.metrics>4.2.26</version.metrics>
         <jackson.version>2.21.5</jackson.version>
+        <jackson.annotations.version>2.21</jackson.annotations.version>
         <jakarta.version>3.1.0</jakarta.version>
         <jersey.version>3.1.11</jersey.version>
         <hk2.version>3.1.1</hk2.version>


### PR DESCRIPTION
## Purpose
$subject

PR #1400 bumped jackson.version to 2.21.5 and reused that same property for jackson-annotations. However, unlike jackson-core and jackson-databind, jackson-annotations stopped publishing patch releases as of 2.20.

Fix: Introduce a separate jackson.annotations.version property set to 2.21

Related: https://github.com/wso2-enterprise/wso2-iam-internal/issues/8055