### PR TITLE
Add httpclient5 5.6.3.wso2v1 orbit bundle

### DIFF
--- a/httpclient5/5.6.3.wso2v1/pom.xml
+++ b/httpclient5/5.6.3.wso2v1/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+    <artifactId>httpclient5</artifactId>
+    <version>5.6.3.wso2v1</version>
+    <packaging>bundle</packaging>
+    <name>Apache HTTP Client 5</name>
+    <description>Apache HTTP Client5 orbit bundle</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${httpclient5.version}</version>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundleplugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.apache.hc.client5.*;version="${project.version}",
+                        </Export-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Import-Package>
+                            org.apache.hc.core5.*;version="${httpcore5.version}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <httpclient5.version>5.6.3</httpclient5.version>
+        <httpcore5.version>5.4.3</httpcore5.version>
+        <maven.bundleplugin.version>2.5.4</maven.bundleplugin.version>
+    </properties>
+</project>

--- a/httpclient5/5.6.3.wso2v1/pom.xml
+++ b/httpclient5/5.6.3.wso2v1/pom.xml
@@ -68,6 +68,7 @@
                         </Private-Package>
                         <Import-Package>
                             org.apache.hc.core5.*;version="${httpcore5.version}",
+                            org.slf4j;version="${slf4j.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>
@@ -78,6 +79,7 @@
     <properties>
         <httpclient5.version>5.6.3</httpclient5.version>
         <httpcore5.version>5.4.3</httpcore5.version>
+        <slf4j.version.range>[1.7,2)</slf4j.version.range>
         <maven.bundleplugin.version>2.5.4</maven.bundleplugin.version>
     </properties>
 </project>

--- a/httpclient5/5.6.3.wso2v1/pom.xml
+++ b/httpclient5/5.6.3.wso2v1/pom.xml
@@ -68,7 +68,6 @@
                         </Private-Package>
                         <Import-Package>
                             org.apache.hc.core5.*;version="${httpcore5.version}",
-                            org.slf4j;version="${slf4j.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>
@@ -79,7 +78,6 @@
     <properties>
         <httpclient5.version>5.6.3</httpclient5.version>
         <httpcore5.version>5.4.3</httpcore5.version>
-        <slf4j.version.range>[1.7,2)</slf4j.version.range>
         <maven.bundleplugin.version>2.5.4</maven.bundleplugin.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
         <module>httpclient5/5.4.1.wso2v1</module>
         <module>httpcore5/5.3.1.wso2v1</module>
         <module>httpcore5/5.4.3.wso2v1</module>
+        <module>httpclient5/5.6.3.wso2v1</module>
         <module>guava/32.1.3.wso2v1</module>
         <module>twilio/9.14.0.wso2v1</module>
         <module>vonage/7.10.0.wso2v1</module>


### PR DESCRIPTION
## Purpose

Adds a new orbit bundle for Apache HttpComponents Client 5 **5.6.3**.

The currently shipped bundle `httpclient5 5.4.1.wso2v1` inlines httpclient5 5.4.1, which is affected by:

| CVE | Severity | Affected | Fixed in |
|---|---|---|---|
| [CVE-2026-64607](https://avd.aquasec.com/nvd/cve-2026-64607) | MEDIUM | httpclient5 < 5.6.3 | 5.6.3 |

> Apache HttpComponents Client: Connection Leak on Content-Encoding Decode Error Leads to Pool Exhaustion

## Approach

New bundle directory `httpclient5/5.6.3.wso2v1`, modelled on the existing `httpclient5/5.4.1.wso2v1`, and registered in the parent pom.

Deliberately kept a **pure version bump** — the new pom differs from `5.4.1.wso2v1`'s only in the version numbers and the copyright year:

```
$ diff <(sed 's/5\.4\.1/VER/g; s/5\.3\.1/CORE/g' httpclient5/5.4.1.wso2v1/pom.xml) \
       <(sed 's/5\.6\.3/VER/g; s/5\.4\.3/CORE/g' httpclient5/5.6.3.wso2v1/pom.xml)
3c3
<   ~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
---
>   ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
```

`Import-Package` pins `org.apache.hc.core5.*` to **5.4.3** — the httpcore5 version httpclient5 5.6.3 is built against (`httpclient5-parent-5.6.3` sets `httpcore.version=5.4.3`). That lines up with the already-released `httpcore5/5.4.3.wso2v1` bundle, which closes CVE-2026-54399 and CVE-2026-54428 on the core5 side.

## Known pre-existing issue, deliberately not addressed here

Neither this bundle nor the shipping `5.4.1.wso2v1` declares an `org.slf4j` import, even though httpclient5 references `org.slf4j.Logger`. The `Import-Package` list is explicit with no trailing wildcard, so bnd emits only what is listed. Neither bundle has a `DynamicImport-Package` or `Require-Bundle` fallback, and IS sets no `org.osgi.framework.bootdelegation`.

Not fixed in this PR, because it is unchanged from what ships today and because a hard `org.slf4j` import would add a **new resolution constraint for every product consuming this orbit bundle** — a range of `[1.7,2)` excludes slf4j 2.x, so a consumer providing 2.x would fail to resolve a bundle that works today. Worth handling separately, across both bundles, with a range that does not regress existing consumers.

## Verification

Built with JDK 21. Resulting manifest:

```
Bundle-SymbolicName: httpclient5
Bundle-Version: 5.6.3.wso2v1
Export-Package: org.apache.hc.client5;version="5.6.3.wso2v1", ...
Import-Package: org.apache.hc.core5.concurrent;version="5.4.3", ...
```

Beyond the bundle itself, I built the **full IS 7.4.0-SNAPSHOT distribution** against it (p2-profile-gen + distribution) — BUILD SUCCESS, 419 MB pack, and p2 installs the bundle cleanly:

```
repository/components/plugins/httpclient5_5.6.3.wso2v1.jar
repository/components/plugins/httpcore5_5.4.3.wso2v1.jar
```

Regression tests on the consuming modules, old versions vs new, all green and identical:

| Module | 5.4.1 / 5.3.1 | 5.6.3 / 5.4.3 |
|---|---|---|
| carbon-kernel `org.wso2.carbon.utils` (incl. `HTTPClientUtilsTest`, `CustomTlsStrategyTest`) | 169 pass | 169 pass |
| carbon-identity-framework `identity.core` | 535 pass | 535 pass |
| carbon-identity-framework `identity.mgt.endpoint.util` | 131 pass | 131 pass |
| carbon-identity-framework `authentication.endpoint.util` | 84 pass | 84 pass |
| identity-governance `captcha` | 76 pass | 76 pass |
| identity-governance `api.user.recovery` | 34 pass | 34 pass |

## Consumer bumps, once this is released

- wso2-extensions/identity-notification-push#29 — **the feature that actually ships these bundles into the IS distribution**
- wso2/carbon-kernel#4619, wso2/carbon-identity-framework#8253, wso2-extensions/identity-governance#1155 — repos that pin the versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
