### PR TITLE
Add yubico-webauthn 2.5.1.wso2v3 orbit bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
         <module>yubico-webauthn/1.12.1.wso2v1</module>
         <module>yubico-webauthn/2.4.0.wso2v2</module>
         <module>yubico-webauthn/2.5.1.wso2v2</module>
+        <module>yubico-webauthn/2.5.1.wso2v3</module>
         <module>asn-one/0.4.0.wso2v1</module>
         <module>smbj/0.10.0.wso2v1</module>
         <module>mbassador/1.3.2.wso2v1</module>

--- a/yubico-webauthn/2.5.1.wso2v3/pom.xml
+++ b/yubico-webauthn/2.5.1.wso2v3/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.yubico.webauthn</groupId>
+    <artifactId>yubico-webauthn</artifactId>
+    <packaging>bundle</packaging>
+    <version>2.5.1.wso2v3</version>
+    <name>WSO2 Carbon Orbit - Yubico Webauthn</name>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.yubico</groupId>
+            <artifactId>webauthn-server-core</artifactId>
+            <version>${com.yubico.webauthn.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-cbor</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.upokecenter</groupId>
+            <artifactId>cbor</artifactId>
+            <version>${com.upokecenter.cbor.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.yubico</groupId>
+            <artifactId>webauthn-server-attestation</artifactId>
+            <version>${com.yubico.webauthn.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${org.apache.httpcomponents.client5.version}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            com.upokecenter.*; version="4.5.2",
+                            COSE
+                        </Private-Package>
+                        <Import-Package>
+                            !com.yubico.webauthn.*,
+                            !com.yubico.internal.*,
+                            com.fasterxml.jackson.core.*; version="${fasterxml.jackson.version.range}",
+                            com.fasterxml.jackson.databind.*; version="${fasterxml.jackson.version.range}",
+                            com.fasterxml.jackson.annotation.*; version="${fasterxml.jackson.version.range}",
+                            com.fasterxml.jackson.datatype.jdk8.*; version="${fasterxml.jackson.version.range}",
+                            com.fasterxml.jackson.dataformat.cbor.*; version="${fasterxml.jackson.version.range}",
+                            org.slf4j.*; version="${slf4j.version.range}",
+                            org.apache.http.*;version="${apache.http.client.version.range}",
+                        </Import-Package>
+                        <Export-Package>
+                            com.yubico.webauthn.*; version=${com.yubico.webauthn.version},
+                            com.yubico.webauthn.data.*; version=${com.yubico.webauthn.version},
+                            com.yubico.webauthn.exception.*; version=${com.yubico.webauthn.version},
+                            com.yubico.fido.*; version=${com.yubico.webauthn.version},
+                            com.yubico.internal.util.*; version=${com.yubico.webauthn.version}
+                        </Export-Package>
+                        <Embed-Dependency>*;scope=compile|runtime;inline=false;</Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <properties>
+        <com.yubico.webauthn.version>2.5.1</com.yubico.webauthn.version>
+        <com.upokecenter.cbor.version>4.5.2</com.upokecenter.cbor.version>
+        <org.apache.httpcomponents.client5.version>5.6.3</org.apache.httpcomponents.client5.version>
+        <apache.http.client.version.range>[4.5.0, 5.0.0)</apache.http.client.version.range>
+        <fasterxml.jackson.version.range>[2.9.5, 3.0.0)</fasterxml.jackson.version.range>
+        <slf4j.version.range>[1.6.1, 2.0.0)</slf4j.version.range>
+    </properties>
+
+</project>


### PR DESCRIPTION
## Problem

`yubico-webauthn 2.5.1.wso2v2` (already released) **cannot be installed into the Identity Server p2 profile.** Building the IS distribution against it fails:

```
Missing requirement: yubico-webauthn 2.5.1.wso2v2 requires
  'java.package; org.slf4j.impl [1.6.1,2.0.0)' but it could not be found
Cannot satisfy dependency:
  From: WSO2 Carbon - FIDO2 Feature (org.wso2.carbon.identity.application.authenticator.fido2.server.feature.group)
  To: org.eclipse.equinox.p2.iu; yubico-webauthn [2.5.1.wso2v2,2.5.1.wso2v2]
```

Nothing in the IS distribution exports `org.slf4j.impl` — I checked the manifest of every bundle in `repository/components/plugins/`. `pax-logging-api` exports `org.slf4j` but not `org.slf4j.impl`.

## Cause

The only functional change in wso2v2 was adding `httpclient5` as a direct dependency:

```xml
<dependency>
    <groupId>org.apache.httpcomponents.client5</groupId>
    <artifactId>httpclient5</artifactId>
    <version>${org.apache.httpcomponents.client5.version}</version>
    <scope>runtime</scope>
</dependency>
```

Unlike every other dependency in that pom, it carries no `slf4j-api` exclusion. With `Embed-Transitive: true`, `slf4j-api-1.7.36.jar` therefore lands on the `Bundle-ClassPath`. bnd analyses it, sees `LoggerFactory` referencing `org.slf4j.impl.StaticLoggerBinder`, and emits a **mandatory** `org.slf4j.impl` import.

Manifest comparison:

| Bundle | slf4j `Import-Package` | Embeds `slf4j-api` |
|---|---|---|
| 2.5.1.wso2v1 | `org.slf4j;version="[1.6.1,2.0.0)"` | no |
| 2.5.1.wso2v2 | `org.slf4j.impl;version="[1.6.1,2.0.0)"` :x: | yes (1.7.36) |
| 2.5.1.wso2v3 | `org.slf4j;version="[1.6.1,2.0.0)"` :white_check_mark: | no |

## Fix

Add the `slf4j-api` exclusion to the `httpclient5` dependency, matching every other dependency in the pom. This restores wso2v1's import while keeping the CVE fixes wso2v2 introduced.

## Verification

Built locally with JDK 21. Embedded jars in `2.5.1.wso2v3`:

```
cbor-4.5.2.jar
httpclient5-5.6.3.jar
httpcore5-5.4.3.jar
httpcore5-h2-5.4.3.jar
jackson-datatype-jsr310-2.22.2.jar
numbers-1.8.2.jar
webauthn-server-attestation-2.5.1.jar
webauthn-server-core-2.5.1.jar
yubico-util-2.5.1.jar
```

so [CVE-2026-64607](https://avd.aquasec.com/nvd/cve-2026-64607), [CVE-2026-54399](https://avd.aquasec.com/nvd/cve-2026-54399) and [CVE-2026-54428](https://avd.aquasec.com/nvd/cve-2026-54428) stay fixed, and `slf4j-api` is no longer embedded.

## Related

- wso2-extensions/identity-local-auth-fido#183 — the consumer bump, retargeted from wso2v2 to wso2v3
- wso2/orbit#1405 — standalone `httpclient5 5.6.3.wso2v1` bundle for the same httpclient5 CVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
