### PR TITLE
Add hazelcast 5.3.7.wso2v2 orbit bundle

### DIFF
--- a/hazelcast/5.3.7.wso2v2/pom.xml
+++ b/hazelcast/5.3.7.wso2v2/pom.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- ~ Copyright (c) 2026, WSO2 LLC. (http://wso2.com) All Rights Reserved.
- ~
- ~ Licensed under the Apache License, Version 2.0 (the "License");
- ~ you may not use this file except in compliance with the License.
- ~ You may obtain a copy of the License at
- ~
- ~      http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~ Unless required by applicable law or agreed to in writing, software
- ~ distributed under the License is distributed on an "AS IS" BASIS,
- ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- ~ See the License for the specific language governing permissions and
- ~ limitations under the License.
--->
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/hazelcast/5.3.7.wso2v2/pom.xml
+++ b/hazelcast/5.3.7.wso2v2/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ Copyright (c) 2026, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.hazelcast</groupId>
+    <artifactId>hazelcast</artifactId>
+    <packaging>bundle</packaging>
+    <name>hazelcast.wso2</name>
+    <version>5.3.7.wso2v2</version>
+    <description>
+        This bundle will export packages from hazelcast
+    </description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>${version.hazelcast}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${version.jackson}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-objects</artifactId>
+            <version>${version.jackson}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-annotation-support</artifactId>
+            <version>${version.jackson}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.hazelcast.*;version="${version.hazelcast.exp.pkg}"
+                        </Export-Package>
+                        <Import-Package>
+                            !sun.misc,
+                            !junit.framework,
+                            !org.junit,
+                            !org.mockito,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Private-Package>
+                        </Private-Package>
+                        <Include-Resource>
+                            @hazelcast-${version.hazelcast}.jar!/META-INF/*,
+                            @hazelcast-${version.hazelcast}.jar!//.properties,
+                            @hazelcast-${version.hazelcast}.jar!/hazelcast-config-*
+                        </Include-Resource>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.jr:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${project.groupId}:${project.artifactId}</artifact>
+                                    <excludes>
+                                        <exclude>com/hazelcast/shaded/com/fasterxml/jackson/**</exclude>
+                                        <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
+                                        <exclude>META-INF/maven/com.fasterxml.jackson.jr/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.fasterxml.jackson.*:*</artifact>
+                                    <excludes>
+                                        <!-- multi-release variants shade cannot relocate correctly -->
+                                        <exclude>META-INF/versions/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>com.hazelcast.shaded.com.fasterxml.jackson</shadedPattern>
+                                    <excludes>
+                                        <!-- hazelcast leaves these unrelocated and imports them -->
+                                        <exclude>com.fasterxml.jackson.annotation.*</exclude>
+                                    </excludes>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <version.hazelcast>5.3.7</version.hazelcast>
+        <version.hazelcast.exp.pkg>5.3.7</version.hazelcast.exp.pkg>
+        <version.jackson>2.22.2</version.jackson>
+    </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
         <module>hazelcast/4.2.5.wso2v1</module>
         <module>hazelcast/4.2.6.wso2v1</module>
         <module>hazelcast/5.3.2.wso2v1</module>
+        <module>hazelcast/5.3.7.wso2v2</module>
         <module>velocity/2.3.0.wso2v1</module>
         <module>tiles/2.0.5.wso2v2</module>
         <module>groovy/2.4.8.wso2v1</module>


### PR DESCRIPTION
## Purpose

Add `hazelcast 5.3.7.wso2v2` — the same bundle as `5.3.7.wso2v1`, carrying Jackson **2.22.2** in place of the Jackson copy Hazelcast keeps inside its own jar.

## Why this needs shading rather than a version bump

Hazelcast doesn't depend on Jackson the way a normal library would. Before publishing its jar, Hazelcast takes a copy of Jackson, **renames its packages** from `com.fasterxml.jackson.*` to
`com.hazelcast.shaded.com.fasterxml.jackson.*`, and compiles its own code against those renamed classes. Both the renamed Jackson classes and Hazelcast's references to them are baked into the artifact we consume.

Three consequences, each ruling out a simpler approach:

1. **There is no version property to change.** No WSO2 pom mentions this Jackson, because it isn't a
   dependency of anything — it is part of Hazelcast's own jar.
2. **Our existing Jackson orbit bundles cannot supply it.** They publish Jackson under its real package name. Hazelcast's compiled code only ever looks for the renamed one, and to the framework those are two unrelated packages.
3. **The copy cannot simply be dropped.** Ten Hazelcast classes are compiled against it — its JSON
   serialization, its JSON query getters, and Jet JSON support. Remove the package and those fail to load.

So changing that inner copy means doing what Hazelcast itself does: take Jackson 2.22.2, rename its packages the same way, and put it in place of the old copy. Renaming packages means rewriting the class files — `maven-bundle-plugin` selects and wraps but cannot rename, so `maven-shade-plugin` relocation is the only step that can do it. Several other orbit bundles already use it this way.

**Hazelcast itself stays at 5.3.7.** Only the Jackson inside the bundle changes.

## What the pom adds

Identical to `5.3.7.wso2v1` apart from the bundle version, plus:

- the three Jackson artifacts as dependencies at 2.22.2, marked `optional` so they don't leak to consumers
- a `maven-shade-plugin` execution that removes Hazelcast's embedded Jackson and relocates 2.22.2
  into the same package
- `<module>hazelcast/5.3.7.wso2v2</module>` in the root `pom.xml`

Two deliberate exclusions, both of which look removable and are not:

- **`jackson-annotations` is not relocated.** Hazelcast's own build leaves it alone too, and the bundle already imports it from the container. Relocating it leaves 18 unresolved references.
- **`META-INF/versions/**` is dropped from the Jackson artifacts.** They are multi-release jars, and shade rewrites those inner class names without moving the files to the new path (MSHADE-406 / MSHADE-439), leaving entries whose location and contents disagree.

## Verification

JDK 21, `mvn clean package` — BUILD SUCCESS. Module resolves in the reactor
(`mvn validate -pl hazelcast/5.3.7.wso2v2`).

- the Jackson inside the bundle is 2.22.2, with no remnants of the old copy and no Jackson classes left outside the renamed package
- `mvn install` publishes the shaded jar, not the pre-shade one
- every class reference into the renamed Jackson package resolves — **1348** references, **0 unresolved**
- **the bundle is externally identical to `5.3.7.wso2v1`**: built with the same toolchain, both produce the same OSGi manifest — 654 `Import-Package` and 571 `Export-Package` entries, same sets, no mandatory imports. It is a drop-in replacement.

`maven-shade-plugin` is pinned at 3.6.2; 3.4.1 cannot read Jackson 2.22.2's Java 21 class files.
