### PR TITLE
Pin maven-bundle-plugin in hazelcast 5.3.7.wso2v2

### DIFF
--- a/hazelcast/5.3.7.wso2v2/pom.xml
+++ b/hazelcast/5.3.7.wso2v2/pom.xml
@@ -70,6 +70,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.4</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
## Purpose

Pin `maven-bundle-plugin` in `hazelcast/5.3.7.wso2v2` to **5.1.4**. Left unpinned, the release build
resolves 4.1.0, which fails on a modern JDK:

```
org.apache.felix:maven-bundle-plugin:4.1.0:bundle ... ConcurrentModificationException
    at java.util.TreeMap.computeIfAbsent (TreeMap.java:639)
    at aQute.bnd.osgi.Jar.putResource (Jar.java:264)
    at aQute.bnd.osgi.Jar.buildFromZip (Jar.java:201)
    at org.apache.felix.bundleplugin.BundlePlugin.getClasspath (BundlePlugin.java:1647)
```

## Cause

`bndlib` 4.1.0 mutates the map it is inside the `computeIfAbsent` of:

```java
Map<String, Resource> s = directories.computeIfAbsent(getDirectory(path), dir -> {
    for (int n = dir.lastIndexOf('/'); n > 0; n = dir.lastIndexOf('/')) {
        dir = dir.substring(0, n);
        if (directories.containsKey(dir)) break;
        directories.put(dir, null);      // structural modification during computeIfAbsent
    }
    return new TreeMap<>();
});
```

Newer JDKs detect that and throw. `bndlib` 5.1.1 — which `maven-bundle-plugin` 5.1.4 uses — does the
same work with plain `get`/`put`, so there is nothing to detect.

## Not introduced by this bundle

Verified matrix on the **unmodified** `hazelcast/5.3.7.wso2v1` pom with `maven-bundle-plugin` 4.1.0:

| JDK | result |
|---|---|
| 8 | builds |
| 11 | builds |
| **17** | **fails, CME** |
| **21** | **fails, CME** |

And the released `hazelcast 5.3.7.wso2v1` in Nexus carries:

```
Tool: Bnd-4.1.0.201810181252
Build-Jdk: 1.8.0_402
```

So 4.1.0 is not newly resolved — it is what this pipeline has always used, and it worked because the
agent ran JDK 8. What changed is the JDK, not the plugin. Pinning 4.1.0 onto the other existing poms
reproduces the same failure, so `5.3.6.wso2v1` (currently shipping), `5.3.7.wso2v1` and
`5.4.0.wso2v1` are all equally unbuildable on the current agent — they are simply not being rebuilt.

## Why pinning is still the right fix here

It makes this bundle build regardless of what the agent offers, and most of the repo already pins the
plugin (2.4.0 in 379 poms, 3.3.0 in 140, 5.1.4 in 24) — these four hazelcast poms are among the few
that do not. The root `pluginManagement` (2.3.7) never applies, because orbit version poms have no
`<parent>`.

Verified building with 3.5.0, 5.1.4 and 5.1.9; only 4.1.0 fails.

> Worth a separate look: the agent's `maven-bundle-plugin` 4.1.0 versus its JDK. Pinning the other
> three hazelcast poms would be a small hardening change.

## Verification

JDK 21, `mvn clean package` — BUILD SUCCESS. `5.3.7.wso2v1` and `5.3.7.wso2v2` built with the same
pinned plugin are equivalent:

- `Import-Package` 622 entries on both, same set, none mandatory
- `Export-Package` 571 entries on both, same set
- relocated Jackson resolves — 1348 class references into
  `com/hazelcast/shaded/com/fasterxml/jackson/`, 0 unresolved
- 0 `META-INF/versions` entries; no Jackson classes outside the relocated package
